### PR TITLE
Add chart download support

### DIFF
--- a/ui/source.go
+++ b/ui/source.go
@@ -19,6 +19,7 @@ var (
 	albumPattern           = regexp.MustCompile(`^(?:https?://)?` + yandexMusicHostPattern + `/album/(?P<albumId>\d+)(?:\?.*)?$`)
 	playlistPattern        = regexp.MustCompile(`^(?:https?://)?` + yandexMusicHostPattern + `/users/(?P<username>[^/]+)/playlists/(?P<playlistId>\d+)(?:\?.*)?$`)
 	playlistUUIDPattern    = regexp.MustCompile(`^(?:https?://)?` + yandexMusicHostPattern + `/playlists/(?P<playlistUuid>(?:[a-z]{2}\.)?[0-9a-fA-F-]{36})(?:\?.*)?$`)
+	chartPattern           = regexp.MustCompile(`^(?:https?://)?` + yandexMusicHostPattern + `/chart(?:/(?P<region>[a-z]+))?(?:\?.*)?$`)
 )
 
 type sourceURLKind int
@@ -28,6 +29,7 @@ const (
 	sourceURLAlbum
 	sourceURLLegacyPlaylist
 	sourceURLPlaylistUUID
+	sourceURLChart
 )
 
 type (
@@ -38,6 +40,7 @@ type (
 		PlaylistID   string
 		PlaylistUUID string
 		Username     string
+		Region       string
 	}
 
 	SourceSubmitMsg struct {
@@ -175,6 +178,12 @@ func (m *SourceModel) parseURL(input string) tea.Msg {
 			PlaylistUUID: playlistID,
 		}
 	}
+	if matches := chartPattern.FindStringSubmatch(input); matches != nil {
+		return URLSubmitMsg{
+			kind:   sourceURLChart,
+			Region: matches[1],
+		}
+	}
 	return nil
 }
 
@@ -195,6 +204,12 @@ func (m *SourceModel) handleURL(msg URLSubmitMsg) tea.Cmd {
 			return SourceSubmitMsg{Album: album}
 		case sourceURLLegacyPlaylist, sourceURLPlaylistUUID:
 			playlist, err := m.fetchPlaylist(msg)
+			if err != nil {
+				return URLHandleErrorMsg(err.Error())
+			}
+			return SourceSubmitMsg{Playlist: playlist}
+		case sourceURLChart:
+			playlist, err := m.client.Chart(msg.Region)
 			if err != nil {
 				return URLHandleErrorMsg(err.Error())
 			}
@@ -223,6 +238,7 @@ func (m SourceModel) View() string {
 	s += dimGrayForeground.Render("\n- Album: https://music.yandex.ru/album/1231231")
 	s += dimGrayForeground.Render("\n- Playlist: https://music.yandex.ru/playlists/4dc94b2f-e96b-2daf-a53c-ce71846901b3")
 	s += dimGrayForeground.Render("\n- Legacy playlist: https://music.yandex.ru/users/username/playlists/12312311")
+	s += dimGrayForeground.Render("\n- Chart: https://music.yandex.ru/chart (or /chart/world)")
 	s += "\n\n"
 	s += m.urlInput.View()
 

--- a/ui/source_test.go
+++ b/ui/source_test.go
@@ -88,6 +88,27 @@ func TestSourceParseURLPlaylistUUIDWithGenericPrefix(t *testing.T) {
 	}, msg)
 }
 
+func TestSourceParseURLChart(t *testing.T) {
+	m := SourceModel{}
+
+	msg := m.parseURL("https://music.yandex.ru/chart?utm_source=web")
+
+	assert.Equal(t, URLSubmitMsg{
+		kind: sourceURLChart,
+	}, msg)
+}
+
+func TestSourceParseURLChartWithRegion(t *testing.T) {
+	m := SourceModel{}
+
+	msg := m.parseURL("https://music.yandex.com/chart/world")
+
+	assert.Equal(t, URLSubmitMsg{
+		kind:   sourceURLChart,
+		Region: "world",
+	}, msg)
+}
+
 func TestSourceParseURLInvalid(t *testing.T) {
 	m := SourceModel{}
 

--- a/ya/client.go
+++ b/ya/client.go
@@ -194,7 +194,11 @@ func (c *Client) Chart(region string) (*model.Playlist, error) {
 		return nil, err
 	}
 
-	return &data.Result.Chart, nil
+	if data.Result.Chart == nil || len(data.Result.Chart.Tracks) == 0 {
+		return nil, fmt.Errorf("chart not found")
+	}
+
+	return data.Result.Chart, nil
 }
 
 func (c *Client) fetchPlaylist(url string) (*model.Playlist, error) {

--- a/ya/client.go
+++ b/ya/client.go
@@ -53,6 +53,7 @@ type YaClient interface {
 	AlbumWithTracks(id string) (*model.Album, error)
 	UsersPlaylist(id string, username string) (*model.Playlist, error)
 	PlaylistByUUID(id string) (*model.Playlist, error)
+	Chart(region string) (*model.Playlist, error)
 	DownloadTrack(track model.Track, outputDir string) (string, error)
 	DownloadTrackWithOptions(track model.Track, outputDir string, options DownloadOptions) (string, error)
 	SetToken(token string)
@@ -175,6 +176,25 @@ func (c *Client) UsersPlaylist(id string, username string) (*model.Playlist, err
 
 func (c *Client) PlaylistByUUID(id string) (*model.Playlist, error) {
 	return c.fetchPlaylist(fmt.Sprintf("%s/playlist/%s", baseURL, id))
+}
+
+func (c *Client) Chart(region string) (*model.Playlist, error) {
+	url := fmt.Sprintf("%s/landing3/chart", baseURL)
+	if region != "" {
+		url = fmt.Sprintf("%s/%s", url, region)
+	}
+
+	res, err := c.httpClient.Get(url)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get chart: %w", err)
+	}
+
+	var data model.ChartResponse
+	if err := parseResponse(res, &data); err != nil {
+		return nil, err
+	}
+
+	return &data.Result.Chart, nil
 }
 
 func (c *Client) fetchPlaylist(url string) (*model.Playlist, error) {

--- a/ya/model/response.go
+++ b/ya/model/response.go
@@ -10,7 +10,7 @@ type PlaylistsResponse struct {
 
 type ChartResponse struct {
 	Result struct {
-		Chart Playlist `json:"chart"`
+		Chart *Playlist `json:"chart"`
 	} `json:"result"`
 }
 

--- a/ya/model/response.go
+++ b/ya/model/response.go
@@ -8,6 +8,12 @@ type PlaylistsResponse struct {
 	Result []Playlist `json:"result"`
 }
 
+type ChartResponse struct {
+	Result struct {
+		Chart Playlist `json:"chart"`
+	} `json:"result"`
+}
+
 type AlbumResponse struct {
 	Result Album `json:"result"`
 }


### PR DESCRIPTION
## Summary
- Adds Yandex Music **chart** as a download source.
- Accepts `https://music.yandex.ru/chart` and region variants like `https://music.yandex.ru/chart/world` (also `russia`, and the `.com/.kz/.by/.uz` hosts).
- Implemented via the `/landing3/chart[/region]` endpoint, whose `chart` field is a regular playlist — so the existing playlist download flow is reused with no changes to downloading.

## Changes
- `ya/model/response.go`: new `ChartResponse` that extracts `result.chart` as a `Playlist`.
- `ya/client.go`: new `Chart(region)` method + `YaClient` interface entry.
- `ui/source.go`: new chart URL pattern, `sourceURLChart` kind, handler, and a help-text example.
- `ui/source_test.go`: parse tests for `/chart` and `/chart/<region>`.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (incl. new chart parse tests)
- [x] Manually downloaded the chart end-to-end with a valid token