### PR TITLE
Warn and exit early when TERM=xterm

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,11 @@ func main() {
 		os.Exit(2)
 	}
 
+	if isKnownProblematicTerm(os.Getenv("TERM")) {
+		fmt.Fprintln(os.Stderr, problematicTermWarning(os.Getenv("TERM")))
+		os.Exit(2)
+	}
+
 	downloadLogger, err := utils.NewDownloadLogger(utils.DefaultDownloadLogPath)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to initialize download logger: %v\n", err)
@@ -74,4 +79,18 @@ func main() {
 	}
 
 	downloadLogger.Info("application stopped")
+}
+
+func isKnownProblematicTerm(term string) bool {
+	return term == "xterm"
+}
+
+func problematicTermWarning(term string) string {
+	return fmt.Sprintf(`Warning: TERM=%s is known to break this terminal UI.
+
+Colors, selected row highlighting, and focus/navigation may not render correctly.
+Run this before starting yamdl again:
+
+  export TERM=xterm-256color
+`, term)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,42 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestIsKnownProblematicTerm(t *testing.T) {
+	tests := []struct {
+		name string
+		term string
+		want bool
+	}{
+		{name: "xterm", term: "xterm", want: true},
+		{name: "xterm 256 color", term: "xterm-256color", want: false},
+		{name: "screen 256 color", term: "screen-256color", want: false},
+		{name: "tmux 256 color", term: "tmux-256color", want: false},
+		{name: "empty", term: "", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isKnownProblematicTerm(tt.term); got != tt.want {
+				t.Fatalf("isKnownProblematicTerm(%q) = %v, want %v", tt.term, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProblematicTermWarning(t *testing.T) {
+	warning := problematicTermWarning("xterm")
+
+	for _, want := range []string{
+		"TERM=xterm",
+		"Colors, selected row highlighting, and focus/navigation",
+		"export TERM=xterm-256color",
+	} {
+		if !strings.Contains(warning, want) {
+			t.Fatalf("warning does not contain %q:\n%s", want, warning)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
This PR adds a startup preflight check for terminals reporting TERM=xterm.

## What changed
- detect TERM=xterm before Bubble Tea starts
- print a clear warning that recommends export TERM=xterm-256color
- exit with status code 2 instead of entering a broken TUI
- add unit tests for the TERM check and warning text

Closes #8