### PR TITLE
Refactor audio artifact publication pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,8 +108,9 @@ For alternative ways to get a token, see the [yandex-music API documentation](ht
 -   Completed tracks show the actual saved format in the status column, for example `✅ FLAC`, `✅ M4A`, or `✅ MP3`
 -   If you stop an active queue, interrupted tracks are returned to `Ready` so you can restart the download cleanly
 -   If needed, you can relaunch the app with `--timeout <seconds>` to limit how long a single file download may take
--   By default, each MP3, FLAC, or M4A file is tagged with title, artist, album metadata, Yandex track URL/source metadata, and embedded JPEG/PNG cover art when available
--   M4A tagging covers native MP4/M4A containers only. The downloader creates the required M4A metadata structure even when Yandex Music returns a valid file without initial tags; damaged M4A files are not repaired. If optional M4A metadata writing fails, the audio file is still saved and the CLI logs a warning
+-   By default, each MP3, FLAC, or M4A file is tagged with title, artist, album metadata, and Yandex track URL/source metadata. Cover art is optional: when available it is embedded during tagging and the temporary cover file is removed after download
+-   MP3 and FLAC are published only after tags are written successfully. If tagging fails, no audio file is left in the download folder
+-   M4A tagging covers native MP4/M4A containers only. The downloader creates the required M4A metadata structure even when Yandex Music returns a valid file without initial tags; damaged M4A files are not repaired. M4A is published even when optional metadata writing fails—the CLI logs a warning and the audio file is still saved
 -   If cover downloads are slow or expensive, relaunch with `--skip-cover=true`; text tags will still be written
 
 ![downloading](assets/img_download_in_progress.png)
@@ -118,7 +119,7 @@ For alternative ways to get a token, see the [yandex-music API documentation](ht
 
 -   The progress bar fills completely upon download completion
 -   Downloaded tracks are available in the `./downloads` directory
--   A track is marked as completed after the audio file is saved. For MP3 and FLAC, metadata tags are written before completion; for M4A, metadata is best-effort and tagging failures do not block delivery. Cover download failures are ignored so they do not block the track
+-   A track is marked as completed after the audio file is saved. For MP3 and FLAC, tagging must succeed before the file appears in `./downloads`; for M4A, metadata is best-effort and tagging failures do not block delivery. Cover download failures are ignored so they do not block the track
 
 ![download complete](assets/img_download_complete.png)
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ For alternative ways to get a token, see the [yandex-music API documentation](ht
 -   If you stop an active queue, interrupted tracks are returned to `Ready` so you can restart the download cleanly
 -   If needed, you can relaunch the app with `--timeout <seconds>` to limit how long a single file download may take
 -   By default, each MP3, FLAC, or M4A file is tagged with title, artist, album metadata, and Yandex track URL/source metadata. Cover art is optional: when available it is embedded during tagging and the temporary cover file is removed after download
--   MP3 and FLAC are published only after tags are written successfully. If tagging fails, no audio file is left in the download folder
+-   MP3 and FLAC of that format are published only after tags are written successfully. If tagging fails, that format is not left in the download folder; in lossless mode a FLAC tagging failure still falls back to MP3
 -   M4A tagging covers native MP4/M4A containers only. The downloader creates the required M4A metadata structure even when Yandex Music returns a valid file without initial tags; damaged M4A files are not repaired. M4A is published even when optional metadata writing fails—the CLI logs a warning and the audio file is still saved
 -   If cover downloads are slow or expensive, relaunch with `--skip-cover=true`; text tags will still be written
 
@@ -119,7 +119,7 @@ For alternative ways to get a token, see the [yandex-music API documentation](ht
 
 -   The progress bar fills completely upon download completion
 -   Downloaded tracks are available in the `./downloads` directory
--   A track is marked as completed after the audio file is saved. For MP3 and FLAC, tagging must succeed before the file appears in `./downloads`; for M4A, metadata is best-effort and tagging failures do not block delivery. Cover download failures are ignored so they do not block the track
+-   A track is marked as completed after the audio file is saved. For MP3 and FLAC of that format, tagging must succeed before the file appears in `./downloads`; in lossless mode a FLAC tagging failure still falls back to MP3. For M4A, metadata is best-effort and tagging failures do not block delivery. Cover download failures are ignored so they do not block the track
 
 ![download complete](assets/img_download_complete.png)
 

--- a/ui/download.go
+++ b/ui/download.go
@@ -15,6 +15,7 @@ import (
 	"charm.land/bubbles/v2/spinner"
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/google/uuid"
 )
 
@@ -421,11 +422,25 @@ func (m DownloadModel) trackListStyle() lipgloss.Style {
 }
 
 func (m DownloadModel) renderTrackList() string {
-	content := m.trackList.View()
+	content := capLinesToWidth(m.trackList.View(), m.trackList.Width())
 	if missingRows := m.trackList.Height() - lipgloss.Height(content); missingRows > 0 {
 		content += strings.Repeat("\n ", missingRows)
 	}
 	return m.trackListStyle().Render(content)
+}
+
+func capLinesToWidth(content string, width int) string {
+	if width <= 0 || content == "" {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+	for i, line := range lines {
+		if ansi.StringWidth(line) > width {
+			lines[i] = ansi.Truncate(line, width, "")
+		}
+	}
+	return strings.Join(lines, "\n")
 }
 
 func (m *DownloadModel) cycleFocus() {

--- a/ui/download_test.go
+++ b/ui/download_test.go
@@ -239,6 +239,13 @@ func TestWindowResizeRendersTrackListAcrossWindowWidth(t *testing.T) {
 	m := NewDownloadModel(nil)
 	addReadyTracks(&m, 40)
 
+	m.tracksProgress[0].status = TrackStatusAlreadyExists
+	m.tracksProgress[1].status = TrackStatusDownloaded
+	m.tracksProgress[1].format = "FLAC"
+	m.tracksProgress[2].status = TrackStatusDownloaded
+	m.tracksProgress[2].format = "MP3"
+	m.updateTrackList()
+
 	updated, _ := m.Update(tea.WindowSizeMsg{Width: 100, Height: 30})
 
 	assert.Equal(t, 100, lipgloss.Width(updated.renderTrackList()))

--- a/ui/tracks_list.go
+++ b/ui/tracks_list.go
@@ -119,21 +119,22 @@ func (t TrackListItem) Render(w io.Writer, m list.Model, index int, listItem lis
 	title := item.Title()
 	desc := item.Description()
 
-	statusStr := fmt.Sprintf("%-*s", trackStatusColumnWidth, item.statusLabel())
+	statusPlain := formatStatusColumn(item.statusLabel())
+	statusStr := statusPlain
 
 	switch item.status {
 	case TrackStatusDuplicate:
-		statusStr = duplicateStatusStyle.Render(statusStr)
+		statusStr = duplicateStatusStyle.Render(statusPlain)
 	case TrackStatusDownloaded:
-		statusStr = downloadedStatusStyle.Render(statusStr)
+		statusStr = downloadedStatusStyle.Render(statusPlain)
 	case TrackStatusError:
-		statusStr = errorStatusStyle.Render(statusStr)
+		statusStr = errorStatusStyle.Render(statusPlain)
 	case TrackStatusNotAvailable:
-		statusStr = notAvailableStatusStyle.Render(statusStr)
+		statusStr = notAvailableStatusStyle.Render(statusPlain)
 	case TrackStatusAlreadyExists:
-		statusStr = alreadyExistsStatusStyle.Render(statusStr)
+		statusStr = alreadyExistsStatusStyle.Render(statusPlain)
 	case TrackStatusReady:
-		statusStr = readyStatusStyle.Render(statusStr)
+		statusStr = readyStatusStyle.Render(statusPlain)
 	}
 
 	isSelected := index == m.Index()
@@ -153,29 +154,29 @@ func (t TrackListItem) Render(w io.Writer, m list.Model, index int, listItem lis
 		titleStyleToUse = selectedItemStyle
 		paddingStyleToUse = selectedItemStyle
 		descStyleToUse = selectedTrackDescriptionStyle
+		statusStr = selectedItemStyle.Render(statusPlain)
 	}
 
-	if isSelected {
-		statusStr = fmt.Sprintf("%-*s", trackStatusColumnWidth, item.statusLabel())
-		statusStr = selectedItemStyle.Render(statusStr)
-	}
+	trackNumberRendered := trackNumberStyleToUse.Render(trackNumber)
+	numberWidth := lipgloss.Width(trackNumberRendered)
+	statusWidth := trackStatusColumnWidth
 
-	textWidth := m.Width() - lipgloss.Width(trackNumberStyleToUse.Render(trackNumber)) - trackStatusColumnWidth
-	if textWidth < minTrackTextWidth {
-		textWidth = minTrackTextWidth
+	textWidth := m.Width() - numberWidth - statusWidth
+	if textWidth < 0 {
+		textWidth = 0
 	}
 
 	combined := trackText(title, desc)
 	displayText := truncateToWidth(combined, textWidth)
 	titlePart, descPart := splitTrackText(displayText, title)
-	paddingWidth := m.Width() - lipgloss.Width(trackNumberStyleToUse.Render(trackNumber)) - lipgloss.Width(displayText) - trackStatusColumnWidth
+	paddingWidth := m.Width() - numberWidth - lipgloss.Width(displayText) - statusWidth
 	if paddingWidth < 0 {
 		paddingWidth = 0
 	}
 	padding := strings.Repeat(" ", paddingWidth)
 
 	str := fmt.Sprintf("%s%s%s%s%s",
-		trackNumberStyleToUse.Render(trackNumber),
+		trackNumberRendered,
 		titleStyleToUse.Render(titlePart),
 		descStyleToUse.Render(descPart),
 		paddingStyleToUse.Render(padding),
@@ -185,10 +186,19 @@ func (t TrackListItem) Render(w io.Writer, m list.Model, index int, listItem lis
 	fmt.Fprint(w, str)
 }
 
-const (
-	trackStatusColumnWidth = 15
-	minTrackTextWidth      = 10
-)
+const trackStatusColumnWidth = 15
+
+func formatStatusColumn(label string) string {
+	return padToWidth(truncateToWidth(label, trackStatusColumnWidth), trackStatusColumnWidth)
+}
+
+func padToWidth(s string, width int) string {
+	current := runewidth.StringWidth(s)
+	if current >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-current)
+}
 
 func trackText(title, desc string) string {
 	if desc == "" {

--- a/ui/tracks_list_test.go
+++ b/ui/tracks_list_test.go
@@ -59,6 +59,47 @@ func TestTrackListItemRenderFillsListWidth(t *testing.T) {
 	assert.Equal(t, 160, ansi.StringWidth(ansi.Strip(row.String())))
 }
 
+func TestTrackListItemRenderDownloadedStatusFitsListWidth(t *testing.T) {
+	formats := []string{"MP3", "FLAC"}
+	for _, format := range formats {
+		t.Run(format, func(t *testing.T) {
+			items := []list.Item{
+				TrackListItem{
+					uid:    "item",
+					track:  &model.Track{Title: "Song"},
+					status: TrackStatusDownloaded,
+					format: format,
+				},
+			}
+			modelList := list.New(items, TrackListItem{}, 80, 20)
+			renderer := TrackListItem{}
+
+			var row bytes.Buffer
+			renderer.Render(&row, modelList, 0, items[0])
+
+			assert.Equal(t, 80, ansi.StringWidth(ansi.Strip(row.String())))
+		})
+	}
+}
+
+func TestTrackListItemRenderLongStatusFitsListWidth(t *testing.T) {
+	items := []list.Item{
+		TrackListItem{
+			uid:    "item",
+			track:  &model.Track{Title: "Song"},
+			status: TrackStatusDownloaded,
+			format: "SUPERLONGFORMATNAME",
+		},
+	}
+	modelList := list.New(items, TrackListItem{}, 80, 20)
+	renderer := TrackListItem{}
+
+	var row bytes.Buffer
+	renderer.Render(&row, modelList, 0, items[0])
+
+	assert.Equal(t, 80, ansi.StringWidth(ansi.Strip(row.String())))
+}
+
 func TestTrackListItemDownloadedStatusIncludesFormat(t *testing.T) {
 	items := []list.Item{
 		TrackListItem{

--- a/utils/http.go
+++ b/utils/http.go
@@ -97,6 +97,10 @@ func (c *HttpClient) SetToken(token string) {
 	c.headers["Authorization"] = fmt.Sprintf("OAuth %s", token)
 }
 
+func (c *HttpClient) SetTransport(rt http.RoundTripper) {
+	c.httpClient.Transport = rt
+}
+
 func (c *HttpClient) SetDownloadTimeout(timeout time.Duration) {
 	if timeout < 0 {
 		timeout = 0

--- a/utils/http.go
+++ b/utils/http.go
@@ -267,67 +267,131 @@ func (c *HttpClient) DownloadBytesWithContext(reqCtx RequestLogContext, url stri
 	return body, nil
 }
 
+func (c *HttpClient) DownloadToWriterWithContext(reqCtx RequestLogContext, url string, writer io.Writer) (int64, error) {
+	return c.downloadResponseToWriter(reqCtx, url, writer, "")
+}
+
 func (c *HttpClient) DownloadFileWithContext(reqCtx RequestLogContext, url, filepath string) error {
+	out, err := c.createTempDownloadFile(filepath)
+	if err != nil {
+		return fmt.Errorf("error creating file: %w", err)
+	}
+	tempPath := out.Name()
+	cleanupTempFile := true
+	defer func() {
+		if out != nil {
+			_ = out.Close()
+		}
+		if cleanupTempFile {
+			_ = os.Remove(tempPath)
+		}
+	}()
+
+	written, err := c.downloadResponseToWriter(reqCtx, url, out, filepath)
+	if err != nil {
+		return err
+	}
+	_ = written
+
+	if err := out.Close(); err != nil {
+		c.logRequest(slog.LevelError, reqCtx, "download file save failed", http.MethodGet, url,
+			"destination", filepath,
+			"error", err,
+		)
+		return fmt.Errorf("error closing temp file: %w", err)
+	}
+	out = nil
+
+	if err := os.Rename(tempPath, filepath); err != nil {
+		c.logRequest(slog.LevelError, reqCtx, "download file save failed", http.MethodGet, url,
+			"destination", filepath,
+			"error", err,
+		)
+		return fmt.Errorf("error renaming temp file: %w", err)
+	}
+
+	cleanupTempFile = false
+	return nil
+}
+
+func (c *HttpClient) downloadResponseToWriter(reqCtx RequestLogContext, url string, writer io.Writer, destination string) (int64, error) {
 	ctx, cancel := withOptionalTimeout(c.baseContext(), c.downloadTimeout)
 	defer cancel()
 
 	req, err := c.createDownloadRequest(ctx, url)
 	if err != nil {
-		c.logRequest(slog.LevelError, reqCtx, "download request create failed", http.MethodGet, url,
-			"destination", filepath,
-			"error", err,
-		)
-		return err
+		args := []any{"error", err}
+		if destination != "" {
+			args = append([]any{"destination", destination}, args...)
+		}
+		c.logRequest(slog.LevelError, reqCtx, "download request create failed", http.MethodGet, url, args...)
+		return 0, err
 	}
 
 	startedAt := time.Now()
-	c.logRequest(slog.LevelInfo, reqCtx, "download request started", http.MethodGet, url,
-		"destination", filepath,
-		"headers", SanitizeHeaders(req.Header),
-	)
+	startArgs := []any{"headers", SanitizeHeaders(req.Header)}
+	if destination != "" {
+		startArgs = append([]any{"destination", destination}, startArgs...)
+	}
+	c.logRequest(slog.LevelInfo, reqCtx, "download request started", http.MethodGet, url, startArgs...)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		c.logRequest(slog.LevelError, reqCtx, "download request failed", http.MethodGet, url,
-			"destination", filepath,
+		failArgs := []any{
 			"duration_ms", time.Since(startedAt).Milliseconds(),
 			"error", err,
-		)
-		return fmt.Errorf("failed to download file: %w", err)
+		}
+		if destination != "" {
+			failArgs = append([]any{"destination", destination}, failArgs...)
+		}
+		c.logRequest(slog.LevelError, reqCtx, "download request failed", http.MethodGet, url, failArgs...)
+		return 0, fmt.Errorf("failed to download file: %w", err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		c.logRequest(slog.LevelError, reqCtx, "download request finished with bad status", http.MethodGet, url,
-			"destination", filepath,
+		badArgs := []any{
 			"status_code", resp.StatusCode,
 			"duration_ms", time.Since(startedAt).Milliseconds(),
 			"response_bytes", len(body),
 			"response_preview", responsePreview(resp.Header.Get("Content-Type"), body),
-		)
-		return fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
+		}
+		if destination != "" {
+			badArgs = append([]any{"destination", destination}, badArgs...)
+		}
+		c.logRequest(slog.LevelError, reqCtx, "download request finished with bad status", http.MethodGet, url, badArgs...)
+		return 0, fmt.Errorf("failed to download file: status code %d", resp.StatusCode)
 	}
 
-	written, err := c.saveResponseToFile(resp.Body, filepath)
+	buf := make([]byte, DefaultBufferSize)
+	written, err := io.CopyBuffer(writer, resp.Body, buf)
 	if err != nil {
-		c.logRequest(slog.LevelError, reqCtx, "download file save failed", http.MethodGet, url,
-			"destination", filepath,
+		copyArgs := []any{
 			"status_code", resp.StatusCode,
 			"duration_ms", time.Since(startedAt).Milliseconds(),
 			"error", err,
-		)
-		return err
+		}
+		if destination != "" {
+			copyArgs = append([]any{"destination", destination}, copyArgs...)
+			c.logRequest(slog.LevelError, reqCtx, "download file save failed", http.MethodGet, url, copyArgs...)
+		} else {
+			c.logRequest(slog.LevelError, reqCtx, "download response copy failed", http.MethodGet, url, copyArgs...)
+		}
+		return written, fmt.Errorf("error writing to file: %w", err)
 	}
 
-	c.logRequest(slog.LevelInfo, reqCtx, "download request finished", http.MethodGet, url,
-		"destination", filepath,
+	finishArgs := []any{
 		"status_code", resp.StatusCode,
 		"duration_ms", time.Since(startedAt).Milliseconds(),
 		"response_bytes", written,
-	)
+	}
+	if destination != "" {
+		finishArgs = append([]any{"destination", destination}, finishArgs...)
+	}
+	c.logRequest(slog.LevelInfo, reqCtx, "download request finished", http.MethodGet, url, finishArgs...)
 
-	return nil
+	return written, nil
 }
 
 func (c *HttpClient) createDownloadRequest(ctx context.Context, url string) (*http.Request, error) {
@@ -341,41 +405,6 @@ func (c *HttpClient) createDownloadRequest(ctx context.Context, url string) (*ht
 	}
 
 	return req, nil
-}
-
-func (c *HttpClient) saveResponseToFile(body io.Reader, filepath string) (int64, error) {
-	out, err := c.createTempDownloadFile(filepath)
-	if err != nil {
-		return 0, fmt.Errorf("error creating file: %w", err)
-	}
-	tempPath := out.Name()
-	cleanupTempFile := true
-	defer func() {
-		if out != nil {
-			_ = out.Close()
-		}
-		if cleanupTempFile {
-			_ = os.Remove(tempPath)
-		}
-	}()
-
-	buf := make([]byte, DefaultBufferSize)
-	written, err := io.CopyBuffer(out, body, buf)
-	if err != nil {
-		return written, fmt.Errorf("error writing to file: %w", err)
-	}
-
-	if err := out.Close(); err != nil {
-		return written, fmt.Errorf("error closing temp file: %w", err)
-	}
-	out = nil
-
-	if err := os.Rename(tempPath, filepath); err != nil {
-		return written, fmt.Errorf("error renaming temp file: %w", err)
-	}
-
-	cleanupTempFile = false
-	return written, nil
 }
 
 func (c *HttpClient) baseContext() context.Context {

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewHttpClient(t *testing.T) {
@@ -40,6 +41,41 @@ func TestSetDownloadTimeout(t *testing.T) {
 
 	client.SetDownloadTimeout(-1 * time.Second)
 	assert.Zero(t, client.downloadTimeout)
+}
+
+func TestSetTransport(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"result":"ok"}`))
+	}))
+	defer server.Close()
+
+	client := NewHttpClient()
+	client.SetTransport(&hostRewriteTransport{
+		targetHost: server.Listener.Addr().String(),
+		base:       http.DefaultTransport,
+	})
+
+	body, err := client.Get("https://api.music.yandex.net/test")
+	require.NoError(t, err)
+	assert.Contains(t, string(body), "ok")
+}
+
+type hostRewriteTransport struct {
+	targetHost string
+	base       http.RoundTripper
+}
+
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = "http"
+	cloned.URL.Host = t.targetHost
+	cloned.Host = t.targetHost
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(cloned)
 }
 
 func TestGet(t *testing.T) {

--- a/utils/http_test.go
+++ b/utils/http_test.go
@@ -135,6 +135,99 @@ func TestPost(t *testing.T) {
 	assert.Equal(t, `{"result": "success"}`, string(resp))
 }
 
+type trackingWriter struct {
+	bytes.Buffer
+	closed bool
+}
+
+func (w *trackingWriter) Close() error {
+	w.closed = true
+	return nil
+}
+
+func TestDownloadToWriterWithContextWritesBytesWithoutClosingWriter(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, http.MethodGet, r.Method)
+		w.Write([]byte("audio-data"))
+	}))
+	defer server.Close()
+
+	client := NewHttpClient()
+	writer := &trackingWriter{}
+
+	written, err := client.DownloadToWriterWithContext(
+		RequestLogContext{Stage: "download_file", Operation: "download_mp3"},
+		server.URL,
+		writer,
+	)
+
+	assert.NoError(t, err)
+	assert.Equal(t, int64(len("audio-data")), written)
+	assert.Equal(t, []byte("audio-data"), writer.Bytes())
+	assert.False(t, writer.closed)
+}
+
+func TestDownloadToWriterWithContextRejectsBadStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte("unavailable"))
+	}))
+	defer server.Close()
+
+	client := NewHttpClient()
+	writer := &trackingWriter{}
+
+	written, err := client.DownloadToWriterWithContext(
+		RequestLogContext{Stage: "download_file", Operation: "download_mp3"},
+		server.URL,
+		writer,
+	)
+
+	assert.Error(t, err)
+	assert.ErrorContains(t, err, "status code 503")
+	assert.Zero(t, written)
+	assert.Empty(t, writer.Bytes())
+	assert.False(t, writer.closed)
+}
+
+func TestDownloadToWriterWithContextStopsOnCancel(t *testing.T) {
+	serverStarted := make(chan struct{})
+	serverCanFinish := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("partial"))
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+
+		close(serverStarted)
+		<-serverCanFinish
+		_, _ = w.Write([]byte(" content"))
+	}))
+	defer server.Close()
+
+	client := NewHttpClient()
+	writer := &trackingWriter{}
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := client.DownloadToWriterWithContext(
+			RequestLogContext{Stage: "download_file", Operation: "download_mp3"},
+			server.URL,
+			writer,
+		)
+		errCh <- err
+	}()
+
+	<-serverStarted
+	client.Cancel()
+	close(serverCanFinish)
+
+	err := <-errCh
+	assert.Error(t, err)
+	assert.False(t, writer.closed)
+}
+
 func TestDownloadFile(t *testing.T) {
 	content := "test file content"
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/ya/audio_artifact.go
+++ b/ya/audio_artifact.go
@@ -148,6 +148,8 @@ func (c *Client) publishAudioArtifact(
 	return artifactPublishResult{Filename: destination, CoverFilename: cover.filename}, nil
 }
 
+var mp3Tagger artifactTagger = mp3ArtifactTagger{}
+
 type mp3ArtifactTagger struct{}
 
 func (mp3ArtifactTagger) Write(path string, metadata artifactMetadata) error {
@@ -180,7 +182,7 @@ func mp3ArtifactSpec() artifactSpec {
 		DownloadStage:      "download_file",
 		MetadataStage:      "id3_tags",
 		CompletionStage:    "id3_tags",
-		Tagger:             mp3ArtifactTagger{},
+		Tagger:             mp3Tagger,
 		FailurePolicy:      metadataRequired,
 		MetadataSuccessMsg: "ID3 metadata written",
 	}

--- a/ya/audio_artifact.go
+++ b/ya/audio_artifact.go
@@ -147,3 +147,66 @@ func (c *Client) publishAudioArtifact(
 	)
 	return artifactPublishResult{Filename: destination, CoverFilename: cover.filename}, nil
 }
+
+type mp3ArtifactTagger struct{}
+
+func (mp3ArtifactTagger) Write(path string, metadata artifactMetadata) error {
+	return writeID3Tags(path, metadata.Track, metadata.CoverPath)
+}
+
+type flacArtifactTagger struct{}
+
+func (flacArtifactTagger) Write(path string, metadata artifactMetadata) error {
+	return writeFLACTags(path, metadata.Track, metadata.CoverPath)
+}
+
+type m4aArtifactTagger struct {
+	client *Client
+}
+
+func (t m4aArtifactTagger) Write(path string, metadata artifactMetadata) error {
+	var album model.Album
+	if first := firstAlbum(metadata.Track); first != nil {
+		album = *first
+	}
+	coverMIME, coverData, _ := readM4ACoverData(metadata.CoverPath)
+	tags := m4aTagInputForTrack(metadata.Track, album, coverMIME, coverData)
+	return t.client.m4aTags().Write(path, tags)
+}
+
+func mp3ArtifactSpec() artifactSpec {
+	return artifactSpec{
+		Format:             "mp3",
+		DownloadStage:      "download_file",
+		MetadataStage:      "id3_tags",
+		CompletionStage:    "id3_tags",
+		Tagger:             mp3ArtifactTagger{},
+		FailurePolicy:      metadataRequired,
+		MetadataSuccessMsg: "ID3 metadata written",
+	}
+}
+
+func flacArtifactSpec() artifactSpec {
+	return artifactSpec{
+		Format:             "flac",
+		DownloadStage:      "download_file",
+		MetadataStage:      "flac_tags",
+		CompletionStage:    "lossless_complete",
+		Tagger:             flacArtifactTagger{},
+		FailurePolicy:      metadataRequired,
+		MetadataSuccessMsg: "FLAC metadata written",
+	}
+}
+
+func (c *Client) m4aArtifactSpec() artifactSpec {
+	return artifactSpec{
+		Format:             "m4a",
+		DownloadStage:      "download_file",
+		MetadataStage:      "m4a_tags",
+		CompletionStage:    "lossless_complete",
+		Tagger:             m4aArtifactTagger{client: c},
+		FailurePolicy:      metadataBestEffort,
+		MetadataSuccessMsg: "M4A metadata written",
+		MetadataSkipMsg:    "M4A metadata skipped; keeping audio",
+	}
+}

--- a/ya/audio_artifact.go
+++ b/ya/audio_artifact.go
@@ -76,29 +76,26 @@ func (c *Client) publishAudioArtifact(
 		return artifactPublishResult{}, fmt.Errorf("error creating artifact temp file: %w", err)
 	}
 	tempFilename := tempFile.Name()
-	_ = tempFile.Close()
-
 	cleanupTemp := true
 	defer func() {
 		if cleanupTemp {
 			_ = os.Remove(tempFilename)
 		}
 	}()
+	if err := tempFile.Close(); err != nil {
+		return artifactPublishResult{}, fmt.Errorf("error closing artifact temp file: %w", err)
+	}
 
-	coverCh := c.startCoverDownload(track, destination, options)
 	if err := writeAudio(tempFilename); err != nil {
 		c.logTrackFailure(trackCtx, spec.DownloadStage, err,
 			"filename", destination,
 			"temp_filename", tempFilename,
 			"format", spec.Format,
 		)
-		cover := c.waitCoverDownload(trackCtx, coverCh)
-		if cover.filename != "" {
-			c.removeCoverFile(trackCtx, cover.filename)
-		}
 		return artifactPublishResult{}, err
 	}
 
+	coverCh := c.startCoverDownload(track, destination, options)
 	cover := c.waitCoverDownload(trackCtx, coverCh)
 	if cover.filename != "" {
 		defer c.removeCoverFile(trackCtx, cover.filename)
@@ -148,8 +145,6 @@ func (c *Client) publishAudioArtifact(
 	return artifactPublishResult{Filename: destination, CoverFilename: cover.filename}, nil
 }
 
-var mp3Tagger artifactTagger = mp3ArtifactTagger{}
-
 type mp3ArtifactTagger struct{}
 
 func (mp3ArtifactTagger) Write(path string, metadata artifactMetadata) error {
@@ -176,13 +171,20 @@ func (t m4aArtifactTagger) Write(path string, metadata artifactMetadata) error {
 	return t.client.m4aTags().Write(path, tags)
 }
 
-func mp3ArtifactSpec() artifactSpec {
+func (c *Client) mp3Tags() artifactTagger {
+	if c == nil || c.mp3Tagger == nil {
+		return mp3ArtifactTagger{}
+	}
+	return c.mp3Tagger
+}
+
+func (c *Client) mp3ArtifactSpec() artifactSpec {
 	return artifactSpec{
 		Format:             "mp3",
 		DownloadStage:      "download_file",
 		MetadataStage:      "id3_tags",
 		CompletionStage:    "id3_tags",
-		Tagger:             mp3Tagger,
+		Tagger:             c.mp3Tags(),
 		FailurePolicy:      metadataRequired,
 		MetadataSuccessMsg: "ID3 metadata written",
 	}

--- a/ya/audio_artifact.go
+++ b/ya/audio_artifact.go
@@ -1,0 +1,149 @@
+package ya
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"ya-music/utils"
+	"ya-music/ya/model"
+)
+
+type artifactMetadata struct {
+	Track     model.Track
+	CoverPath string
+}
+
+type artifactTagger interface {
+	Write(path string, metadata artifactMetadata) error
+}
+
+type artifactWriteFunc func(path string) error
+
+type metadataFailurePolicy uint8
+
+const (
+	metadataRequired metadataFailurePolicy = iota
+	metadataBestEffort
+)
+
+type artifactSpec struct {
+	Format             string
+	DownloadStage      string
+	MetadataStage      string
+	CompletionStage    string
+	Tagger             artifactTagger
+	FailurePolicy      metadataFailurePolicy
+	MetadataSuccessMsg string
+	MetadataSkipMsg    string
+}
+
+type artifactPublishResult struct {
+	Filename      string
+	CoverFilename string
+}
+
+func (c *Client) publishAudioArtifact(
+	track model.Track,
+	destination string,
+	options DownloadOptions,
+	spec artifactSpec,
+	writeAudio artifactWriteFunc,
+) (artifactPublishResult, error) {
+	if spec.Tagger == nil {
+		return artifactPublishResult{}, fmt.Errorf("artifact tagger is required")
+	}
+	if writeAudio == nil {
+		return artifactPublishResult{}, fmt.Errorf("artifact writer is required")
+	}
+	if strings.TrimSpace(destination) == "" {
+		return artifactPublishResult{}, fmt.Errorf("empty destination path")
+	}
+	destDir := filepath.Dir(destination)
+	dirInfo, err := os.Stat(destDir)
+	if err != nil {
+		return artifactPublishResult{}, fmt.Errorf("destination directory unavailable: %w", err)
+	}
+	if !dirInfo.IsDir() {
+		return artifactPublishResult{}, fmt.Errorf("destination parent is not a directory: %s", destDir)
+	}
+
+	trackCtx := utils.NewTrackLogContext(track)
+
+	tempFile, err := os.CreateTemp(destDir, "."+filepath.Base(destination)+".artifact-*")
+	if err != nil {
+		return artifactPublishResult{}, fmt.Errorf("error creating artifact temp file: %w", err)
+	}
+	tempFilename := tempFile.Name()
+	_ = tempFile.Close()
+
+	cleanupTemp := true
+	defer func() {
+		if cleanupTemp {
+			_ = os.Remove(tempFilename)
+		}
+	}()
+
+	coverCh := c.startCoverDownload(track, destination, options)
+	if err := writeAudio(tempFilename); err != nil {
+		c.logTrackFailure(trackCtx, spec.DownloadStage, err,
+			"filename", destination,
+			"temp_filename", tempFilename,
+			"format", spec.Format,
+		)
+		cover := c.waitCoverDownload(trackCtx, coverCh)
+		if cover.filename != "" {
+			c.removeCoverFile(trackCtx, cover.filename)
+		}
+		return artifactPublishResult{}, err
+	}
+
+	cover := c.waitCoverDownload(trackCtx, coverCh)
+	if cover.filename != "" {
+		defer c.removeCoverFile(trackCtx, cover.filename)
+	}
+
+	metadata := artifactMetadata{Track: track, CoverPath: cover.filename}
+	if err := spec.Tagger.Write(tempFilename, metadata); err != nil {
+		if spec.FailurePolicy == metadataRequired {
+			c.logTrackFailure(trackCtx, spec.MetadataStage, err,
+				"filename", destination,
+				"temp_filename", tempFilename,
+				"cover_filename", cover.filename,
+			)
+			return artifactPublishResult{Filename: destination, CoverFilename: cover.filename},
+				fmt.Errorf("failed to write %s tags: %w", spec.Format, err)
+		}
+
+		c.logTrack(slog.LevelWarn, trackCtx, spec.MetadataSkipMsg,
+			"stage", spec.MetadataStage,
+			"filename", destination,
+			"temp_filename", tempFilename,
+			"error", err,
+		)
+	} else {
+		c.logTrack(slog.LevelInfo, trackCtx, spec.MetadataSuccessMsg,
+			"stage", spec.MetadataStage,
+			"filename", destination,
+			"cover_filename", cover.filename,
+		)
+	}
+
+	if err := os.Rename(tempFilename, destination); err != nil {
+		c.logTrackFailure(trackCtx, spec.DownloadStage, err,
+			"filename", destination,
+			"temp_filename", tempFilename,
+			"format", spec.Format,
+		)
+		return artifactPublishResult{}, fmt.Errorf("failed to publish %s file: %w", spec.Format, err)
+	}
+	cleanupTemp = false
+
+	c.logTrack(slog.LevelInfo, trackCtx, "success",
+		"stage", spec.CompletionStage,
+		"filename", destination,
+		"cover_filename", cover.filename,
+	)
+	return artifactPublishResult{Filename: destination, CoverFilename: cover.filename}, nil
+}

--- a/ya/audio_artifact_test.go
+++ b/ya/audio_artifact_test.go
@@ -1,0 +1,386 @@
+package ya
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"ya-music/utils"
+	"ya-music/ya/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testAudioPayload = "audio-data"
+
+type recordingArtifactTagger struct {
+	paths   []string
+	err     error
+	onWrite func(path string, metadata artifactMetadata)
+}
+
+func (t *recordingArtifactTagger) Write(path string, metadata artifactMetadata) error {
+	t.paths = append(t.paths, path)
+	if t.onWrite != nil {
+		t.onWrite(path, metadata)
+	}
+	return t.err
+}
+
+func assertNoArtifactTempFiles(t *testing.T, dir string) {
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	for _, entry := range entries {
+		assert.NotContains(t, entry.Name(), ".artifact-", "leftover temp file: %s", entry.Name())
+	}
+}
+
+func newCoverTestServer(t *testing.T) *httptest.Server {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("cover-bytes"))
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func testArtifactSpec(tagger artifactTagger, policy metadataFailurePolicy) artifactSpec {
+	return artifactSpec{
+		Format:             "mp3",
+		DownloadStage:      "download_file",
+		MetadataStage:      "id3_tags",
+		CompletionStage:    "mp3_complete",
+		Tagger:             tagger,
+		FailurePolicy:      policy,
+		MetadataSuccessMsg: "ID3 metadata written",
+		MetadataSkipMsg:    "ID3 metadata skipped; keeping audio",
+	}
+}
+
+func writeAudioBytes(payload string) artifactWriteFunc {
+	return func(path string) error {
+		return os.WriteFile(path, []byte(payload), 0644)
+	}
+}
+
+func TestPublishAudioArtifactPublishesAfterRequiredTags(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+	coverServer := newCoverTestServer(t)
+
+	track := model.Track{
+		ID:       model.FlexibleID("1"),
+		Title:    "Song",
+		CoverURI: coverServer.URL + "/%%",
+	}
+
+	var writerPath string
+	writeAudio := func(path string) error {
+		writerPath = path
+		return writeAudioBytes(testAudioPayload)(path)
+	}
+
+	tagger := &recordingArtifactTagger{}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudio,
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, destination, result.Filename)
+	assert.Equal(t, buildCoverFilename(destination), result.CoverFilename)
+
+	assert.Contains(t, writerPath, ".artifact-")
+	assert.NotEqual(t, destination, writerPath)
+	require.Len(t, tagger.paths, 1)
+	assert.Equal(t, writerPath, tagger.paths[0])
+
+	data, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	assert.Equal(t, testAudioPayload, string(data))
+
+	_, err = os.Stat(buildCoverFilename(destination))
+	assert.True(t, os.IsNotExist(err))
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactRemovesTempWhenRequiredTagsFail(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+	coverServer := newCoverTestServer(t)
+
+	track := model.Track{
+		ID:       model.FlexibleID("1"),
+		Title:    "Song",
+		CoverURI: coverServer.URL + "/%%",
+	}
+
+	tagger := &recordingArtifactTagger{err: errors.New("tag failure")}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudioBytes(testAudioPayload),
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write mp3 tags")
+	assert.Equal(t, destination, result.Filename)
+
+	_, err = os.Stat(destination)
+	assert.True(t, os.IsNotExist(err))
+
+	_, err = os.Stat(buildCoverFilename(destination))
+	assert.True(t, os.IsNotExist(err))
+
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactPublishesRawAudioWhenBestEffortTagsFail(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+
+	track := model.Track{
+		ID:    model.FlexibleID("1"),
+		Title: "Song",
+	}
+
+	tagger := &recordingArtifactTagger{err: errors.New("tag failure")}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{SkipCover: true},
+		testArtifactSpec(tagger, metadataBestEffort),
+		writeAudioBytes(testAudioPayload),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, destination, result.Filename)
+
+	data, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	assert.Equal(t, testAudioPayload, string(data))
+
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactCleansCoverWhenAudioWriteFails(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+	coverServer := newCoverTestServer(t)
+
+	track := model.Track{
+		ID:       model.FlexibleID("1"),
+		Title:    "Song",
+		CoverURI: coverServer.URL + "/%%",
+	}
+
+	writeErr := errors.New("write failed")
+	writeAudio := func(path string) error {
+		return writeErr
+	}
+
+	tagger := &recordingArtifactTagger{}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudio,
+	)
+
+	assert.ErrorIs(t, err, writeErr)
+	assert.Empty(t, result.Filename)
+	assert.Empty(t, tagger.paths)
+
+	_, err = os.Stat(destination)
+	assert.True(t, os.IsNotExist(err))
+
+	_, err = os.Stat(buildCoverFilename(destination))
+	assert.True(t, os.IsNotExist(err))
+
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactTagsTempFileBeforeRename(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+
+	track := model.Track{
+		ID:    model.FlexibleID("1"),
+		Title: "Song",
+	}
+
+	tagger := &recordingArtifactTagger{
+		onWrite: func(path string, metadata artifactMetadata) {
+			_, statErr := os.Stat(destination)
+			assert.True(t, os.IsNotExist(statErr), "destination must not exist before rename")
+			assert.Contains(t, path, ".artifact-")
+		},
+	}
+	client := NewClient(utils.NewHttpClient())
+
+	_, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{SkipCover: true},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudioBytes(testAudioPayload),
+	)
+	require.NoError(t, err)
+
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactRejectsInvalidDestination(t *testing.T) {
+	client := NewClient(utils.NewHttpClient())
+	track := model.Track{ID: model.FlexibleID("1"), Title: "Song"}
+	tagger := &recordingArtifactTagger{}
+
+	t.Run("empty destination", func(t *testing.T) {
+		result, err := client.publishAudioArtifact(
+			track,
+			"",
+			DownloadOptions{SkipCover: true},
+			testArtifactSpec(tagger, metadataRequired),
+			writeAudioBytes(testAudioPayload),
+		)
+		assert.Error(t, err)
+		assert.Empty(t, result.Filename)
+	})
+
+	t.Run("missing directory", func(t *testing.T) {
+		dir := t.TempDir()
+		destination := filepath.Join(dir, "missing", "track.mp3")
+		result, err := client.publishAudioArtifact(
+			track,
+			destination,
+			DownloadOptions{SkipCover: true},
+			testArtifactSpec(tagger, metadataRequired),
+			writeAudioBytes(testAudioPayload),
+		)
+		assert.Error(t, err)
+		assert.Empty(t, result.Filename)
+		assertNoArtifactTempFiles(t, dir)
+	})
+}
+
+func TestPublishAudioArtifactRejectsNilDependencies(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+	client := NewClient(utils.NewHttpClient())
+	track := model.Track{ID: model.FlexibleID("1"), Title: "Song"}
+
+	t.Run("nil tagger", func(t *testing.T) {
+		spec := testArtifactSpec(nil, metadataRequired)
+		result, err := client.publishAudioArtifact(
+			track,
+			destination,
+			DownloadOptions{SkipCover: true},
+			spec,
+			writeAudioBytes(testAudioPayload),
+		)
+		assert.Error(t, err)
+		assert.Empty(t, result.Filename)
+		assertNoArtifactTempFiles(t, dir)
+	})
+
+	t.Run("nil writer", func(t *testing.T) {
+		tagger := &recordingArtifactTagger{}
+		result, err := client.publishAudioArtifact(
+			track,
+			destination,
+			DownloadOptions{SkipCover: true},
+			testArtifactSpec(tagger, metadataRequired),
+			nil,
+		)
+		assert.Error(t, err)
+		assert.Empty(t, result.Filename)
+		assert.Empty(t, tagger.paths)
+		assertNoArtifactTempFiles(t, dir)
+	})
+}
+
+func TestPublishAudioArtifactCleansTempOnRenameFailure(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+	require.NoError(t, os.Mkdir(destination, 0755))
+
+	track := model.Track{
+		ID:    model.FlexibleID("1"),
+		Title: "Song",
+	}
+	tagger := &recordingArtifactTagger{}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{SkipCover: true},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudioBytes(testAudioPayload),
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to publish mp3 file")
+	assert.Empty(t, result.Filename)
+	assertNoArtifactTempFiles(t, dir)
+}
+
+func TestPublishAudioArtifactContinuesWhenCoverDownloadFails(t *testing.T) {
+	dir := t.TempDir()
+	destination := filepath.Join(dir, "track.mp3")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	t.Cleanup(server.Close)
+
+	track := model.Track{
+		ID:       model.FlexibleID("1"),
+		Title:    "Song",
+		CoverURI: server.URL + "/%%",
+	}
+	tagger := &recordingArtifactTagger{}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudioBytes(testAudioPayload),
+	)
+
+	require.NoError(t, err)
+	assert.Equal(t, destination, result.Filename)
+	assert.Empty(t, result.CoverFilename)
+
+	data, err := os.ReadFile(destination)
+	require.NoError(t, err)
+	assert.Equal(t, testAudioPayload, string(data))
+
+	_, err = os.Stat(buildCoverFilename(destination))
+	assert.True(t, os.IsNotExist(err))
+
+	assertNoArtifactTempFiles(t, dir)
+}

--- a/ya/audio_artifact_test.go
+++ b/ya/audio_artifact_test.go
@@ -10,6 +10,9 @@ import (
 	"ya-music/utils"
 	"ya-music/ya/model"
 
+	"github.com/bogem/id3v2/v2"
+	"github.com/go-flac/flacvorbis"
+	flac "github.com/go-flac/go-flac"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -412,4 +415,207 @@ func TestPublishAudioArtifactContinuesWhenCoverDownloadFails(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	assertNoArtifactTempFiles(t, dir)
+}
+
+func testArtifactTrack() model.Track {
+	return model.Track{
+		ID:      model.FlexibleID("123"),
+		Title:   "Song",
+		Version: "Live",
+		Artists: []model.Artist{{Name: "Artist A"}, {Name: "Artist B"}},
+		Albums: []model.Album{{
+			ID:    model.FlexibleID("456"),
+			Title: "Album",
+			Genre: "indie",
+			Year:  2025,
+			TrackPosition: model.TrackPosition{
+				Index: 3,
+			},
+		}},
+	}
+}
+
+func TestAudioArtifactMp3TaggerWritesID3Tags(t *testing.T) {
+	dir := t.TempDir()
+	mp3Path := filepath.Join(dir, "track.mp3")
+	coverPath := filepath.Join(dir, "cover.png")
+	require.NoError(t, os.WriteFile(mp3Path, []byte("audio payload"), 0644))
+	require.NoError(t, os.WriteFile(coverPath, tinyPNG, 0644))
+
+	track := testArtifactTrack()
+	tagger := mp3ArtifactTagger{}
+	require.NoError(t, tagger.Write(mp3Path, artifactMetadata{Track: track, CoverPath: coverPath}))
+
+	tag, err := id3v2.Open(mp3Path, id3v2.Options{Parse: true})
+	require.NoError(t, err)
+	defer tag.Close()
+
+	assert.Equal(t, "Song Live", tag.Title())
+	assert.Equal(t, "Artist A, Artist B", tag.Artist())
+	assert.Equal(t, "Album", tag.Album())
+	assert.Len(t, tag.GetFrames(tag.CommonID("Attached picture")), 1)
+}
+
+func TestAudioArtifactMp3TaggerReturnsWriteID3TagsError(t *testing.T) {
+	tagger := mp3ArtifactTagger{}
+	missing := filepath.Join(t.TempDir(), "missing.mp3")
+
+	err := tagger.Write(missing, artifactMetadata{Track: model.Track{Title: "Song"}})
+	want := writeID3Tags(missing, model.Track{Title: "Song"}, "")
+	require.Error(t, err)
+	assert.Equal(t, want.Error(), err.Error())
+}
+
+func TestAudioArtifactFlacTaggerWritesFLACTags(t *testing.T) {
+	dir := t.TempDir()
+	flacPath := filepath.Join(dir, "track.flac")
+	coverPath := filepath.Join(dir, "cover.png")
+	require.NoError(t, os.WriteFile(flacPath, minimalFLACBytes(), 0644))
+	require.NoError(t, os.WriteFile(coverPath, onePixelPNG(), 0644))
+
+	track := testArtifactTrack()
+	tagger := flacArtifactTagger{}
+	require.NoError(t, tagger.Write(flacPath, artifactMetadata{Track: track, CoverPath: coverPath}))
+
+	file, err := flac.ParseFile(flacPath)
+	require.NoError(t, err)
+
+	var comments *flacvorbis.MetaDataBlockVorbisComment
+	var hasPicture bool
+	for _, block := range file.Meta {
+		switch block.Type {
+		case flac.VorbisComment:
+			comments, err = flacvorbis.ParseFromMetaDataBlock(*block)
+			require.NoError(t, err)
+		case flac.Picture:
+			hasPicture = true
+		}
+	}
+
+	require.NotNil(t, comments)
+	assertFLACComment(t, comments, "TITLE", "Song Live")
+	assertFLACComment(t, comments, "ALBUM", "Album")
+	assert.True(t, hasPicture)
+}
+
+func TestAudioArtifactFlacTaggerReturnsWriteFLACTagsError(t *testing.T) {
+	tagger := flacArtifactTagger{}
+	missing := filepath.Join(t.TempDir(), "missing.flac")
+
+	err := tagger.Write(missing, artifactMetadata{Track: model.Track{Title: "Song"}})
+	want := writeFLACTags(missing, model.Track{Title: "Song"}, "")
+	require.Error(t, err)
+	assert.Equal(t, want.Error(), err.Error())
+}
+
+func TestAudioArtifactM4aTaggerDelegatesToClientM4ATagger(t *testing.T) {
+	client := NewClient(utils.NewHttpClient())
+	recorder := &recordingM4ATagger{}
+	client.m4aTagger = recorder
+
+	track := testArtifactTrack()
+	album := *firstAlbum(track)
+	coverPath := filepath.Join(t.TempDir(), "cover.png")
+	require.NoError(t, os.WriteFile(coverPath, onePixelPNG(), 0644))
+
+	tagger := m4aArtifactTagger{client: client}
+	path := "/tmp/track.m4a"
+	require.NoError(t, tagger.Write(path, artifactMetadata{Track: track, CoverPath: coverPath}))
+
+	require.Equal(t, 1, recorder.calls)
+	assert.Equal(t, []string{path}, recorder.paths)
+	assert.Equal(t, m4aTagInputForTrack(track, album, "image/png", onePixelPNG()), recorder.lastTags)
+}
+
+func TestAudioArtifactM4aTaggerCoverHandling(t *testing.T) {
+	track := testArtifactTrack()
+	album := *firstAlbum(track)
+	client := NewClient(utils.NewHttpClient())
+	path := "/tmp/track.m4a"
+
+	t.Run("png cover", func(t *testing.T) {
+		recorder := &recordingM4ATagger{}
+		client.m4aTagger = recorder
+		coverPath := filepath.Join(t.TempDir(), "cover.png")
+		require.NoError(t, os.WriteFile(coverPath, onePixelPNG(), 0644))
+
+		tagger := m4aArtifactTagger{client: client}
+		require.NoError(t, tagger.Write(path, artifactMetadata{Track: track, CoverPath: coverPath}))
+
+		assert.Equal(t, "image/png", recorder.lastTags.CoverMIME)
+		assert.Equal(t, onePixelPNG(), recorder.lastTags.CoverData)
+	})
+
+	t.Run("jpeg cover", func(t *testing.T) {
+		recorder := &recordingM4ATagger{}
+		client.m4aTagger = recorder
+		coverPath := filepath.Join(t.TempDir(), "cover.jpg")
+		require.NoError(t, os.WriteFile(coverPath, onePixelJPEG(), 0644))
+
+		tagger := m4aArtifactTagger{client: client}
+		require.NoError(t, tagger.Write(path, artifactMetadata{Track: track, CoverPath: coverPath}))
+
+		assert.Equal(t, "image/jpeg", recorder.lastTags.CoverMIME)
+		assert.Equal(t, onePixelJPEG(), recorder.lastTags.CoverData)
+	})
+
+	t.Run("missing cover", func(t *testing.T) {
+		recorder := &recordingM4ATagger{}
+		client.m4aTagger = recorder
+
+		tagger := m4aArtifactTagger{client: client}
+		require.NoError(t, tagger.Write(path, artifactMetadata{Track: track, CoverPath: ""}))
+
+		want := m4aTagInputForTrack(track, album, "", nil)
+		assert.Equal(t, want, recorder.lastTags)
+		assert.Empty(t, recorder.lastTags.CoverMIME)
+		assert.Empty(t, recorder.lastTags.CoverData)
+	})
+}
+
+func TestAudioArtifactMp3Spec(t *testing.T) {
+	spec := mp3ArtifactSpec()
+
+	assert.Equal(t, "mp3", spec.Format)
+	assert.Equal(t, "download_file", spec.DownloadStage)
+	assert.Equal(t, "id3_tags", spec.MetadataStage)
+	assert.Equal(t, "id3_tags", spec.CompletionStage)
+	assert.Equal(t, metadataRequired, spec.FailurePolicy)
+	assert.Equal(t, "ID3 metadata written", spec.MetadataSuccessMsg)
+	assert.Empty(t, spec.MetadataSkipMsg)
+	require.NotNil(t, spec.Tagger)
+	_, ok := spec.Tagger.(mp3ArtifactTagger)
+	assert.True(t, ok)
+}
+
+func TestAudioArtifactFlacSpec(t *testing.T) {
+	spec := flacArtifactSpec()
+
+	assert.Equal(t, "flac", spec.Format)
+	assert.Equal(t, "download_file", spec.DownloadStage)
+	assert.Equal(t, "flac_tags", spec.MetadataStage)
+	assert.Equal(t, "lossless_complete", spec.CompletionStage)
+	assert.Equal(t, metadataRequired, spec.FailurePolicy)
+	assert.Equal(t, "FLAC metadata written", spec.MetadataSuccessMsg)
+	assert.Empty(t, spec.MetadataSkipMsg)
+	require.NotNil(t, spec.Tagger)
+	_, ok := spec.Tagger.(flacArtifactTagger)
+	assert.True(t, ok)
+}
+
+func TestAudioArtifactM4aSpec(t *testing.T) {
+	client := NewClient(utils.NewHttpClient())
+	spec := client.m4aArtifactSpec()
+
+	assert.Equal(t, "m4a", spec.Format)
+	assert.Equal(t, "download_file", spec.DownloadStage)
+	assert.Equal(t, "m4a_tags", spec.MetadataStage)
+	assert.Equal(t, "lossless_complete", spec.CompletionStage)
+	assert.Equal(t, metadataBestEffort, spec.FailurePolicy)
+	assert.Equal(t, "M4A metadata written", spec.MetadataSuccessMsg)
+	assert.Equal(t, "M4A metadata skipped; keeping audio", spec.MetadataSkipMsg)
+	require.NotNil(t, spec.Tagger)
+	taggers, ok := spec.Tagger.(m4aArtifactTagger)
+	require.True(t, ok)
+	assert.Same(t, client, taggers.client)
 }

--- a/ya/audio_artifact_test.go
+++ b/ya/audio_artifact_test.go
@@ -346,6 +346,35 @@ func TestPublishAudioArtifactCleansTempOnRenameFailure(t *testing.T) {
 	assertNoArtifactTempFiles(t, dir)
 }
 
+func TestPublishAudioArtifactFailsWhenCreateTempFails(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.Chmod(dir, 0555))
+	t.Cleanup(func() { _ = os.Chmod(dir, 0755) })
+
+	destination := filepath.Join(dir, "track.mp3")
+	track := model.Track{ID: model.FlexibleID("1"), Title: "Song"}
+	tagger := &recordingArtifactTagger{}
+	client := NewClient(utils.NewHttpClient())
+
+	result, err := client.publishAudioArtifact(
+		track,
+		destination,
+		DownloadOptions{SkipCover: true},
+		testArtifactSpec(tagger, metadataRequired),
+		writeAudioBytes(testAudioPayload),
+	)
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "error creating artifact temp file")
+	assert.Empty(t, result.Filename)
+	assert.Empty(t, tagger.paths)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+
+	assertNoArtifactTempFiles(t, dir)
+}
+
 func TestPublishAudioArtifactContinuesWhenCoverDownloadFails(t *testing.T) {
 	dir := t.TempDir()
 	destination := filepath.Join(dir, "track.mp3")

--- a/ya/audio_artifact_test.go
+++ b/ya/audio_artifact_test.go
@@ -187,7 +187,13 @@ func TestPublishAudioArtifactPublishesRawAudioWhenBestEffortTagsFail(t *testing.
 func TestPublishAudioArtifactCleansCoverWhenAudioWriteFails(t *testing.T) {
 	dir := t.TempDir()
 	destination := filepath.Join(dir, "track.mp3")
-	coverServer := newCoverTestServer(t)
+	var coverRequests int
+	coverServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		coverRequests++
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("cover-bytes"))
+	}))
+	t.Cleanup(coverServer.Close)
 
 	track := model.Track{
 		ID:       model.FlexibleID("1"),
@@ -214,6 +220,7 @@ func TestPublishAudioArtifactCleansCoverWhenAudioWriteFails(t *testing.T) {
 	assert.ErrorIs(t, err, writeErr)
 	assert.Empty(t, result.Filename)
 	assert.Empty(t, tagger.paths)
+	assert.Zero(t, coverRequests, "cover download must not start when audio write fails")
 
 	_, err = os.Stat(destination)
 	assert.True(t, os.IsNotExist(err))
@@ -574,7 +581,8 @@ func TestAudioArtifactM4aTaggerCoverHandling(t *testing.T) {
 }
 
 func TestAudioArtifactMp3Spec(t *testing.T) {
-	spec := mp3ArtifactSpec()
+	client := NewClient(nil)
+	spec := client.mp3ArtifactSpec()
 
 	assert.Equal(t, "mp3", spec.Format)
 	assert.Equal(t, "download_file", spec.DownloadStage)

--- a/ya/client.go
+++ b/ya/client.go
@@ -488,23 +488,7 @@ func (c *Client) downloadTrackLossless(track model.Track, outputDir string, opti
 		return "", fmt.Errorf("failed to download lossless audio: %w", err)
 	}
 
-	tempFilename, err := writeTempAudioFile(filename, data)
-	if err != nil {
-		c.logTrackFailure(trackCtx, "download_file", err,
-			"filename", filename,
-			"format", AudioFormatFLAC,
-		)
-		return "", fmt.Errorf("failed to write lossless file: %w", err)
-	}
-
-	cleanupTemp := true
-	defer func() {
-		if cleanupTemp {
-			_ = os.Remove(tempFilename)
-		}
-	}()
-
-	coverFilename := ""
+	var spec artifactSpec
 	switch strings.ToLower(strings.TrimSpace(info.Codec)) {
 	case "flac":
 		if !bytes.HasPrefix(data, []byte("fLaC")) {
@@ -514,49 +498,9 @@ func (c *Client) downloadTrackLossless(track model.Track, outputDir string, opti
 			)
 			return "", err
 		}
-
-		coverCh := c.startCoverDownload(track, filename, options)
-		cover := c.waitCoverDownload(trackCtx, coverCh)
-		if cover.filename != "" {
-			coverFilename = cover.filename
-			defer c.removeCoverFile(trackCtx, cover.filename)
-		}
-
-		if err := writeFLACTags(tempFilename, track, cover.filename); err != nil {
-			c.logTrackFailure(trackCtx, "flac_tags", err,
-				"filename", filename,
-				"cover_filename", cover.filename,
-			)
-			return filename, fmt.Errorf("failed to write flac tags: %w", err)
-		}
+		spec = flacArtifactSpec()
 	case "flac-mp4":
-		coverCh := c.startCoverDownload(track, filename, options)
-		cover := c.waitCoverDownload(trackCtx, coverCh)
-		if cover.filename != "" {
-			coverFilename = cover.filename
-			defer c.removeCoverFile(trackCtx, cover.filename)
-		}
-
-		coverMIME, coverData, _ := readM4ACoverData(cover.filename)
-		album := model.Album{}
-		if first := firstAlbum(track); first != nil {
-			album = *first
-		}
-		tags := m4aTagInputForTrack(track, album, coverMIME, coverData)
-		if err := c.m4aTags().Write(tempFilename, tags); err != nil {
-			c.logTrack(slog.LevelWarn, trackCtx, "M4A metadata skipped; keeping audio",
-				"stage", "m4a_tags",
-				"filename", filename,
-				"temp_filename", tempFilename,
-				"error", err,
-			)
-		} else {
-			c.logTrack(slog.LevelInfo, trackCtx, "M4A metadata written",
-				"stage", "m4a_tags",
-				"filename", filename,
-				"cover_filename", cover.filename,
-			)
-		}
+		spec = c.m4aArtifactSpec()
 	default:
 		err := fmt.Errorf("%w: codec %q", lossless.ErrNoFLACDownloadInfo, info.Codec)
 		c.logTrackFailure(trackCtx, "lossless_download", err,
@@ -565,23 +509,22 @@ func (c *Client) downloadTrackLossless(track model.Track, outputDir string, opti
 		return "", err
 	}
 
-	if err := os.Rename(tempFilename, filename); err != nil {
-		c.logTrackFailure(trackCtx, "download_file", err,
-			"filename", filename,
-			"temp_filename", tempFilename,
-			"format", AudioFormatFLAC,
-		)
-		return "", fmt.Errorf("failed to save lossless file: %w", err)
-	}
-	cleanupTemp = false
-
-	c.logTrack(slog.LevelInfo, trackCtx, "success",
-		"stage", "lossless_complete",
-		"filename", filename,
-		"cover_filename", coverFilename,
+	result, err := c.publishAudioArtifact(
+		track,
+		filename,
+		options,
+		spec,
+		func(tempFilename string) error {
+			if err := os.WriteFile(tempFilename, data, 0600); err != nil {
+				return fmt.Errorf("write lossless temp file: %w", err)
+			}
+			return nil
+		},
 	)
-
-	return filename, nil
+	if err != nil {
+		return result.Filename, err
+	}
+	return result.Filename, nil
 }
 
 func (c *Client) waitCoverDownload(trackCtx utils.TrackLogContext, coverCh <-chan coverDownloadResult) coverDownloadResult {
@@ -652,31 +595,6 @@ func pickBestBitrate(info []model.DownloadInfo) model.DownloadInfo {
 	})
 
 	return info[0]
-}
-
-func writeTempAudioFile(destination string, data []byte) (string, error) {
-	tempFile, err := os.CreateTemp(filepath.Dir(destination), filepath.Base(destination)+".*.part")
-	if err != nil {
-		return "", fmt.Errorf("error creating temp file: %w", err)
-	}
-	tempFilename := tempFile.Name()
-	cleanup := true
-	defer func() {
-		_ = tempFile.Close()
-		if cleanup {
-			_ = os.Remove(tempFilename)
-		}
-	}()
-
-	if _, err := tempFile.Write(data); err != nil {
-		return "", fmt.Errorf("error writing temp file: %w", err)
-	}
-	if err := tempFile.Close(); err != nil {
-		return "", fmt.Errorf("error closing temp file: %w", err)
-	}
-
-	cleanup = false
-	return tempFilename, nil
 }
 
 func losslessExtensionForCodec(codec string) string {

--- a/ya/client.go
+++ b/ya/client.go
@@ -75,6 +75,7 @@ type Client struct {
 	logger             *utils.DownloadLogger
 	losslessDownloader losslessTrackDownloader
 	mp3Downloader      trackDownloadFunc
+	mp3Tagger          artifactTagger
 	m4aTagger          m4aTagger
 	userUID            int
 	username           string
@@ -400,26 +401,32 @@ func (c *Client) downloadTrackMP3(track model.Track, outputDir string, options D
 		track,
 		filename,
 		options,
-		mp3ArtifactSpec(),
-		func(tempFilename string) error {
+		c.mp3ArtifactSpec(),
+		func(tempFilename string) (err error) {
 			file, err := os.OpenFile(tempFilename, os.O_WRONLY|os.O_TRUNC, 0600)
 			if err != nil {
 				return fmt.Errorf("open MP3 temp file: %w", err)
 			}
 
-			written, downloadErr := c.httpClient.DownloadToWriterWithContext(
+			var written int64
+			defer func() {
+				closeErr := file.Close()
+				if closeErr == nil {
+					return
+				}
+				if err == nil {
+					err = fmt.Errorf("close MP3 temp file after %d bytes: %w", written, closeErr)
+					return
+				}
+				err = errors.Join(err, closeErr)
+			}()
+
+			written, err = c.httpClient.DownloadToWriterWithContext(
 				c.requestContext(trackCtx, "download_file", "download_mp3"),
 				link,
 				file,
 			)
-			closeErr := file.Close()
-			if downloadErr != nil {
-				return fmt.Errorf("failed to download file: %w", downloadErr)
-			}
-			if closeErr != nil {
-				return fmt.Errorf("close MP3 temp file after %d bytes: %w", written, closeErr)
-			}
-			return nil
+			return err
 		},
 	)
 	if err != nil {

--- a/ya/client.go
+++ b/ya/client.go
@@ -396,38 +396,36 @@ func (c *Client) downloadTrackMP3(track model.Track, outputDir string, options D
 		return "", fmt.Errorf("failed to get download link: %w", err)
 	}
 
-	coverCh := c.startCoverDownload(track, filename, options)
-	if err := c.httpClient.DownloadFileWithContext(c.requestContext(trackCtx, "download_file", "download_mp3"), link, filename); err != nil {
-		cover := c.waitCoverDownload(trackCtx, coverCh)
-		if cover.filename != "" {
-			c.removeCoverFile(trackCtx, cover.filename)
-		}
-		c.logTrackFailure(trackCtx, "download_file", err,
-			"filename", filename,
-		)
-		return "", fmt.Errorf("failed to download file: %w", err)
-	}
+	result, err := c.publishAudioArtifact(
+		track,
+		filename,
+		options,
+		mp3ArtifactSpec(),
+		func(tempFilename string) error {
+			file, err := os.OpenFile(tempFilename, os.O_WRONLY|os.O_TRUNC, 0600)
+			if err != nil {
+				return fmt.Errorf("open MP3 temp file: %w", err)
+			}
 
-	cover := c.waitCoverDownload(trackCtx, coverCh)
-	if cover.filename != "" {
-		defer c.removeCoverFile(trackCtx, cover.filename)
-	}
-
-	if err := writeID3Tags(filename, track, cover.filename); err != nil {
-		c.logTrackFailure(trackCtx, "id3_tags", err,
-			"filename", filename,
-			"cover_filename", cover.filename,
-		)
-		return filename, fmt.Errorf("failed to write id3 tags: %w", err)
-	}
-
-	c.logTrack(slog.LevelInfo, trackCtx, "success",
-		"stage", "id3_tags",
-		"filename", filename,
-		"cover_filename", cover.filename,
+			written, downloadErr := c.httpClient.DownloadToWriterWithContext(
+				c.requestContext(trackCtx, "download_file", "download_mp3"),
+				link,
+				file,
+			)
+			closeErr := file.Close()
+			if downloadErr != nil {
+				return fmt.Errorf("failed to download file: %w", downloadErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close MP3 temp file after %d bytes: %w", written, closeErr)
+			}
+			return nil
+		},
 	)
-
-	return filename, nil
+	if err != nil {
+		return result.Filename, err
+	}
+	return result.Filename, nil
 }
 
 func (c *Client) downloadTrackLossless(track model.Track, outputDir string, options DownloadOptions) (string, error) {

--- a/ya/client_test.go
+++ b/ya/client_test.go
@@ -689,12 +689,8 @@ func TestDownloadTrackMP3ReturnsTaggerErrorWithoutPartialDestination(t *testing.
 	client := newMP3TestClient(t, ts)
 	destination := buildTrackFilename(track, outputDir)
 
-	originalTagger := mp3Tagger
 	tagger := &recordingArtifactTagger{err: errors.New("tag failure")}
-	mp3Tagger = tagger
-	t.Cleanup(func() {
-		mp3Tagger = originalTagger
-	})
+	client.mp3Tagger = tagger
 
 	filename, err := client.DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
 

--- a/ya/client_test.go
+++ b/ya/client_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
+	"encoding/xml"
 	"errors"
 	"net/http"
 	"net/http/httptest"
@@ -16,6 +18,7 @@ import (
 	"ya-music/ya/lossless"
 	"ya-music/ya/model"
 
+	"github.com/bogem/id3v2/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -60,10 +63,21 @@ func TestDownloadTrackReturnsAlreadyExistsSentinel(t *testing.T) {
 	filename := buildTrackFilename(track, outputDir)
 	require.NoError(t, os.WriteFile(filename, []byte("existing"), 0644))
 
-	gotFilename, err := NewClient(nil).DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
+	var httpCalls int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		httpCalls++
+		t.Errorf("unexpected HTTP request: %s %s", r.Method, r.URL.Path)
+	}))
+	t.Cleanup(server.Close)
+
+	httpClient := utils.NewHttpClient()
+	httpClient.SetTransport(&hostRewriteTransport{targetHost: server.Listener.Addr().String()})
+
+	gotFilename, err := NewClient(httpClient).DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
 
 	assert.Equal(t, filename, gotFilename)
 	assert.ErrorIs(t, err, ErrTrackAlreadyExists)
+	assert.Zero(t, httpCalls)
 }
 
 func TestDownloadTrackReturnsAlreadyExistsSentinelForFLACFormat(t *testing.T) {
@@ -420,6 +434,179 @@ func TestDownloadTrackWithOptionsDoesNotDownloadLosslessWhenTargetExists(t *test
 	assert.ErrorIs(t, err, ErrTrackAlreadyExists)
 	assert.Equal(t, 1, fakeLossless.infoCalls)
 	assert.Zero(t, fakeLossless.downloadCalls)
+}
+
+type hostRewriteTransport struct {
+	targetHost string
+	base       http.RoundTripper
+}
+
+func (t *hostRewriteTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	cloned.URL.Scheme = "http"
+	cloned.URL.Host = t.targetHost
+	cloned.Host = t.targetHost
+
+	base := t.base
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return base.RoundTrip(cloned)
+}
+
+type mp3TestServer struct {
+	server   *httptest.Server
+	requests []string
+}
+
+type mp3TestServerConfig struct {
+	trackID        string
+	mp3Payload     []byte
+	downloadStatus int
+}
+
+func newMP3TestServer(t *testing.T, cfg mp3TestServerConfig) *mp3TestServer {
+	t.Helper()
+
+	if cfg.trackID == "" {
+		cfg.trackID = "42"
+	}
+	if cfg.mp3Payload == nil {
+		cfg.mp3Payload = []byte("audio payload")
+	}
+	if cfg.downloadStatus == 0 {
+		cfg.downloadStatus = http.StatusOK
+	}
+
+	ts := &mp3TestServer{}
+	infoURL := "https://api.music.yandex.net/download-info-xml"
+	ts.server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ts.requests = append(ts.requests, r.Method+" "+r.URL.Path)
+
+		switch {
+		case r.URL.Path == "/tracks/"+cfg.trackID+"/download-info":
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(model.DownloadInfoResponse{
+				Result: []model.DownloadInfo{{
+					BitrateInKbps:   320,
+					Codec:           "mp3",
+					DownloadInfoURL: infoURL,
+				}},
+			})
+		case r.URL.Path == "/download-info-xml":
+			w.Header().Set("Content-Type", "application/xml")
+			_ = xml.NewEncoder(w).Encode(model.TrackDownloadInfo{
+				Host: "strm.test",
+				Path: "/mp3/track",
+				Ts:   "123",
+				S:    "secret",
+			})
+		case strings.HasPrefix(r.URL.Path, "/get-mp3/"):
+			if cfg.downloadStatus != http.StatusOK {
+				w.WriteHeader(cfg.downloadStatus)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write(cfg.mp3Payload)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	t.Cleanup(ts.server.Close)
+	return ts
+}
+
+func newMP3TestClient(t *testing.T, ts *mp3TestServer) *Client {
+	t.Helper()
+
+	httpClient := utils.NewHttpClient()
+	httpClient.SetTransport(&hostRewriteTransport{targetHost: ts.server.Listener.Addr().String()})
+	return NewClient(httpClient)
+}
+
+func TestDownloadTrackMP3PublishesThroughArtifactPipeline(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("42"),
+		Title:     "Song",
+		Available: true,
+		Artists:   []model.Artist{{Name: "Artist"}},
+	}
+
+	ts := newMP3TestServer(t, mp3TestServerConfig{trackID: "42"})
+	client := newMP3TestClient(t, ts)
+
+	filename, err := client.DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
+
+	require.NoError(t, err)
+	assert.Equal(t, buildTrackFilename(track, outputDir), filename)
+
+	tag, err := id3v2.Open(filename, id3v2.Options{Parse: true})
+	require.NoError(t, err)
+	defer tag.Close()
+	assert.Equal(t, "Song", tag.Title())
+	assert.Equal(t, "Artist", tag.Artist())
+
+	assert.Contains(t, ts.requests, "GET /tracks/42/download-info")
+	assert.Contains(t, ts.requests, "GET /download-info-xml")
+	assert.True(t, strings.Contains(ts.requests[len(ts.requests)-1], "GET /get-mp3/"))
+	assertNoArtifactTempFiles(t, outputDir)
+}
+
+func TestDownloadTrackMP3ReturnsDownloadErrorWithoutPartialDestination(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("42"),
+		Title:     "Song",
+		Available: true,
+	}
+
+	ts := newMP3TestServer(t, mp3TestServerConfig{
+		trackID:        "42",
+		downloadStatus: http.StatusServiceUnavailable,
+	})
+	client := newMP3TestClient(t, ts)
+	destination := buildTrackFilename(track, outputDir)
+
+	filename, err := client.DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to download file")
+	assert.Empty(t, filename)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+	assertNoArtifactTempFiles(t, outputDir)
+}
+
+func TestDownloadTrackMP3ReturnsTaggerErrorWithoutPartialDestination(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("42"),
+		Title:     "Song",
+		Available: true,
+	}
+
+	ts := newMP3TestServer(t, mp3TestServerConfig{trackID: "42"})
+	client := newMP3TestClient(t, ts)
+	destination := buildTrackFilename(track, outputDir)
+
+	originalTagger := mp3Tagger
+	tagger := &recordingArtifactTagger{err: errors.New("tag failure")}
+	mp3Tagger = tagger
+	t.Cleanup(func() {
+		mp3Tagger = originalTagger
+	})
+
+	filename, err := client.DownloadTrackWithOptions(track, outputDir, DownloadOptions{})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write mp3 tags")
+	assert.Equal(t, destination, filename)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+	assertNoArtifactTempFiles(t, outputDir)
 }
 
 func TestBuildTrackFilenameUsesCanonicalArtistTrackPattern(t *testing.T) {

--- a/ya/client_test.go
+++ b/ya/client_test.go
@@ -305,12 +305,7 @@ func TestDownloadTrackWithOptionsKeepsM4AWhenTaggingFails(t *testing.T) {
 	assert.Equal(t, 1, tagger.calls)
 	assert.Contains(t, logs.String(), "M4A metadata skipped; keeping audio")
 	assert.Contains(t, logs.String(), "tag boom")
-
-	entries, err := os.ReadDir(outputDir)
-	require.NoError(t, err)
-	for _, entry := range entries {
-		assert.False(t, strings.HasSuffix(entry.Name(), ".part"), "temporary file left behind: %s", entry.Name())
-	}
+	assertNoArtifactTempFiles(t, outputDir)
 }
 
 func TestDownloadTrackWithOptionsKeepsM4AWhenCoverFails(t *testing.T) {
@@ -388,7 +383,7 @@ func TestDownloadTrackWithOptionsDoesNotTouchExistingFinalM4AOnTagFailure(t *tes
 	require.NoError(t, err)
 	require.Len(t, tagger.paths, 1)
 	assert.NotEqual(t, filename, tagger.paths[0])
-	assert.Contains(t, tagger.paths[0], ".part")
+	assert.Contains(t, tagger.paths[0], ".artifact-")
 	assert.Equal(t, unrelatedBefore, sha256File(t, unrelated))
 	assert.FileExists(t, filename)
 }
@@ -408,6 +403,109 @@ func TestMalformedM4AFixtureCopyPreservesChecksum(t *testing.T) {
 
 	assert.Equal(t, copyHashBefore, sha256File(t, copyPath))
 	assert.Equal(t, sourceHashBefore, sha256File(t, sourcePath))
+}
+
+func TestDownloadTrackWithOptionsRejectsInvalidFLACMagic(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("13"),
+		Title:     "Song",
+		Available: true,
+	}
+	client := NewClient(nil)
+	client.userUID = 1
+	client.losslessDownloader = &fakeLosslessDownloader{
+		info: lossless.DownloadInfo{Quality: "lossless", Codec: "flac", Bitrate: 1411},
+		data: []byte("not-flac-data"),
+	}
+
+	destination := buildTrackFilenameWithExtension(track, outputDir, ".flac")
+	filename, err := client.downloadTrackLossless(track, outputDir, DownloadOptions{AudioFormat: AudioFormatFLAC})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "lossless response is not a flac stream")
+	assert.Empty(t, filename)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+	assertNoArtifactTempFiles(t, outputDir)
+}
+
+func TestDownloadTrackWithOptionsRejectsUnknownLosslessCodec(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("14"),
+		Title:     "Song",
+		Available: true,
+	}
+	client := NewClient(nil)
+	client.userUID = 1
+	client.losslessDownloader = &fakeLosslessDownloader{
+		info: lossless.DownloadInfo{Quality: "lossless", Codec: "alac", Bitrate: 1411},
+		data: []byte("audio"),
+	}
+
+	destination := buildTrackFilenameWithExtension(track, outputDir, ".flac")
+	filename, err := client.downloadTrackLossless(track, outputDir, DownloadOptions{AudioFormat: AudioFormatFLAC})
+
+	assert.Error(t, err)
+	assert.ErrorIs(t, err, lossless.ErrNoFLACDownloadInfo)
+	assert.Empty(t, filename)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+	assertNoArtifactTempFiles(t, outputDir)
+}
+
+func TestDownloadTrackWithOptionsReturnsFLACTagErrorWithoutDestination(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("15"),
+		Title:     "Song",
+		Available: true,
+		Artists:   []model.Artist{{Name: "Artist"}},
+	}
+	client := NewClient(nil)
+	client.userUID = 1
+	client.losslessDownloader = &fakeLosslessDownloader{
+		info: lossless.DownloadInfo{Quality: "lossless", Codec: "flac", Bitrate: 1411},
+		data: []byte("fLaCinvalid"),
+	}
+
+	destination := buildTrackFilenameWithExtension(track, outputDir, ".flac")
+	filename, err := client.downloadTrackLossless(track, outputDir, DownloadOptions{AudioFormat: AudioFormatFLAC})
+
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "failed to write flac tags")
+	assert.Equal(t, destination, filename)
+
+	_, statErr := os.Stat(destination)
+	assert.True(t, os.IsNotExist(statErr))
+	assertNoArtifactTempFiles(t, outputDir)
+}
+
+func TestDownloadTrackWithOptionsFallsBackToMP3WhenFLACTaggingFails(t *testing.T) {
+	outputDir := t.TempDir()
+	track := model.Track{
+		ID:        model.FlexibleID("16"),
+		Title:     "Song",
+		Available: true,
+	}
+	client := NewClient(nil)
+	client.userUID = 1
+	client.losslessDownloader = &fakeLosslessDownloader{
+		info: lossless.DownloadInfo{Quality: "lossless", Codec: "flac", Bitrate: 1411},
+		data: []byte("fLaCinvalid"),
+	}
+	client.mp3Downloader = func(_ model.Track, _ string, options DownloadOptions) (string, error) {
+		assert.Equal(t, AudioFormatFLAC, options.FormatOrDefault())
+		return "fallback.mp3", nil
+	}
+
+	filename, err := client.DownloadTrackWithOptions(track, outputDir, DownloadOptions{AudioFormat: AudioFormatFLAC})
+
+	require.NoError(t, err)
+	assert.Equal(t, "fallback.mp3", filename)
 }
 
 func TestDownloadTrackWithOptionsDoesNotDownloadLosslessWhenTargetExists(t *testing.T) {


### PR DESCRIPTION
## Summary

This PR unifies MP3, FLAC, and M4A publication into a single atomic **audio artifact publisher** pipeline. All formats now follow the same lifecycle: write to a temp file in the destination directory, optionally download cover art, write metadata tags, then atomically rename to the final filename. The final file never appears until tagging policy allows publication.

Additionally, minor TUI fixes improve track list rendering and status column alignment.

**+1509 / −224 lines** across 11 files.

## Motivation

Previously, MP3, FLAC, and M4A each had separate publication paths with duplicated temp-file handling, cover cleanup, and error policies. This made it harder to reason about when a file becomes visible in `./downloads` and increased the risk of leaving partial files on disk.

The refactor centralizes that logic while preserving all existing public APIs, filename conventions, `ErrTrackAlreadyExists` behavior, and format selection.

## Architecture

### New module: `ya/audio_artifact.go`

Introduces an internal publication pipeline:

| Type | Purpose |
|------|---------|
| `artifactSpec` | Per-format config: stages, tagger, failure policy |
| `artifactTagger` | Interface for writing tags (MP3/FLAC/M4A adapters) |
| `artifactWriteFunc` | Callback that writes raw audio bytes to the temp file |
| `publishAudioArtifact()` | Orchestrates temp file → write audio → cover → tags → rename |

**Temp file naming:** `.<basename>.artifact-*` in the destination directory. Cleaned up on any failure; renamed to final path only on success.

**Metadata failure policies:**
- **MP3 / FLAC** (`metadataRequired`): tagging failure aborts publication — no final file is left in the download folder
- **M4A** (`metadataBestEffort`): tagging failure logs a warning (`M4A metadata skipped; keeping audio`) and still publishes the audio

### HTTP streaming: `utils/http.go`

- New `DownloadToWriterWithContext()` — streams HTTP response body into a provided `io.Writer` without closing it
- Extracted shared `downloadResponseToWriter()` used by both `DownloadToWriterWithContext` and `DownloadFileWithContext`
- `DownloadFileWithContext` now also uses temp-file + rename (consistent atomic behavior)
- Added `SetTransport()` for test injection

### Client integration: `ya/client.go`

- **MP3**: streams download directly into artifact temp file via `DownloadToWriterWithContext` (no intermediate full-file write)
- **FLAC / M4A (lossless)**: writes pre-fetched bytes into artifact temp file, then publishes through the same pipeline
- Removed `writeTempAudioFile()` helper — superseded by artifact publisher
- Format-specific tagging logic moved into `mp3ArtifactTagger`, `flacArtifactTagger`, `m4aArtifactTagger`

### UI improvements

- **`ui/tracks_list.go`**: fixed status column width calculation — padding now accounts for ANSI/style width correctly; removed `minTrackTextWidth` floor that caused overflow
- **`ui/download.go`**: added `capLinesToWidth()` to truncate rendered track list lines to viewport width

### Documentation: `README.md`

Clarified tagging policy differences:
- MP3/FLAC require successful tagging before the file appears
- M4A is published even when optional metadata writing fails
- Cover art is optional and temp cover files are cleaned up after download

## Commits (9)

1. `refactor: stream downloads into writers`
2. `refactor: add atomic audio artifact publisher`
3. `test: cover artifact CreateTemp failure`
4. `refactor: hide format-specific artifact tagging`
5. `refactor: publish MP3 through artifact pipeline`
6. `refactor: publish lossless audio atomically`
7. `refactor: unify audio artifact publication`
8. `refactor: enhance audio artifact tagging and cover handling`
9. `refactor: improve track rendering and status formatting in download UI`

## What is preserved (no behavior changes)

- Public `YaClient` method signatures and return values
- Final filename patterns and `ErrTrackAlreadyExists`
- MP3 / FLAC / M4A format selection logic
- All M4A safety checks: size limits, MP4 container validation, metadata tree creation, co64/stco fix, covr handling, source URL field, refusal to repair damaged files
- Log stages: `download_file`, `id3_tags`, `flac_tags`, `m4a_tags`, `lossless_complete`
- Cover download failures do not block audio delivery
- FLAC tagging failure in lossless mode still falls back to MP3
- No new dependencies in `go.mod`

## Test coverage

| File | New tests |
|------|-----------|
| `ya/audio_artifact_test.go` | 629 lines — atomic publication, cleanup on failure, both metadata policies, temp file leak prevention |
| `ya/client_test.go` | +297 lines — MP3/FLAC/M4A regression tests, fallback behavior, no leftover `.artifact-*` files |
| `utils/http_test.go` | +129 lines — `DownloadToWriterWithContext` success, HTTP errors, cancellation, writer-not-closed guarantee |
| `ui/tracks_list_test.go` | +41 lines — status column width and truncation |
| `ui/download_test.go` | +7 lines — line width capping |

## Test plan

- [x] `go test ./...` — all packages pass
- [x] Download an MP3 track — verify file appears only after tags are written
- [x] Download a FLAC track in lossless mode — verify atomic publication
- [x] Download an M4A (flac-mp4 codec) track — verify audio saved even if metadata write fails (check warning in logs)
- [x] Verify no `.artifact-*` temp files remain in `./downloads` after success or failure
- [x] Verify `--skip-cover=true` still writes text tags without cover
- [x] Check TUI track list alignment with long track titles and various status labels (✅ FLAC, Ready, Error, etc.)
- [x] Confirm FLAC tagging failure triggers MP3 fallback in lossless mode