### PR TITLE
Add non-interactive batch download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,39 @@ A GUI application for downloading tracks from the Yandex Music streaming service
 -   Optional: set a download timeout in seconds: `./yamdl --timeout 180`
 -   Optional: skip cover download and embedding to save time and traffic: `./yamdl --skip-cover=true`
 
+## Batch Downloads
+
+Use `download` to fetch a track, album, playlist, or chart without opening the terminal UI:
+
+```bash
+./yamdl download \
+  --token abc123 \
+  --link https://music.yandex.ru/album/123 \
+  --format mp3 \
+  --output ./downloads
+```
+
+Available options:
+
+- `--token` and `--link` are required.
+- `--format mp3|flac` selects MP3 or lossless download; MP3 is the default.
+- `--output <directory>` selects the destination; `./downloads` is the default.
+- `--timeout <seconds>` and `--skip-cover` work the same way as in the terminal UI.
+
+Each track is printed with its source position and state, for example:
+
+```text
+  1. Artist — Track title — downloading
+  1. Artist — Track title — done (mp3)
+  2. Artist — Another track — skipped: already exists
+  3. Artist — Restricted track — skipped: unavailable
+
+Finished: 1 downloaded, 2 skipped, 0 failed
+Output: ./downloads
+```
+
+Errors for individual tracks appear in the final summary but do not make a completed batch command fail. Invalid arguments, an invalid token, or a source that cannot be resolved return a non-zero exit code. Interrupting the command with Ctrl+C or SIGTERM returns exit code 130 after printing the summary for tracks processed so far.
+
 ## Authentication Token
 
 An OAuth token is required for accessing certain tracks and playlists.

--- a/batch/download.go
+++ b/batch/download.go
@@ -1,0 +1,135 @@
+package batch
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"ya-music/ya"
+	"ya-music/ya/model"
+)
+
+const DefaultConcurrency = 3
+
+type Status string
+
+const (
+	StatusDownloading Status = "downloading"
+	StatusDone        Status = "done"
+	StatusSkipped     Status = "skipped"
+	StatusError       Status = "error"
+)
+
+type Event struct {
+	Index  int
+	Track  model.Track
+	Status Status
+	Format string
+	Reason string
+}
+
+type trackDownloader interface {
+	DownloadTrackWithOptions(model.Track, string, ya.DownloadOptions) (string, error)
+}
+
+type Config struct {
+	Client      trackDownloader
+	Tracks      []model.Track
+	OutputDir   string
+	Options     ya.DownloadOptions
+	Concurrency int
+}
+
+// Run downloads all eligible tracks and reports immutable lifecycle events.
+func Run(config Config) <-chan Event {
+	events := make(chan Event)
+	concurrency := config.Concurrency
+	if concurrency <= 0 {
+		concurrency = DefaultConcurrency
+	}
+
+	go func() {
+		defer close(events)
+
+		seenIDs := make(map[string]struct{}, len(config.Tracks))
+		seenNames := make(map[string]struct{}, len(config.Tracks))
+		sem := make(chan struct{}, concurrency)
+		var workers sync.WaitGroup
+
+		for position, track := range config.Tracks {
+			event := Event{Index: position + 1, Track: track}
+			if !track.Available {
+				event.Status = StatusSkipped
+				event.Reason = "unavailable"
+				events <- event
+				continue
+			}
+
+			id := track.ID.String()
+			name := track.FullTitle() + " - " + track.ArtistsString()
+			if _, exists := seenIDs[id]; exists {
+				event.Status = StatusSkipped
+				event.Reason = "duplicate"
+				events <- event
+				continue
+			}
+			if _, exists := seenNames[name]; exists {
+				event.Status = StatusSkipped
+				event.Reason = "duplicate"
+				events <- event
+				continue
+			}
+			seenIDs[id] = struct{}{}
+			seenNames[name] = struct{}{}
+
+			workers.Add(1)
+			go func(event Event) {
+				defer workers.Done()
+				defer func() {
+					if recovered := recover(); recovered != nil {
+						event.Status = StatusError
+						event.Reason = fmt.Sprintf("panic: %v", recovered)
+						events <- event
+					}
+				}()
+
+				sem <- struct{}{}
+				defer func() { <-sem }()
+
+				event.Status = StatusDownloading
+				events <- event
+
+				filename, err := config.Client.DownloadTrackWithOptions(event.Track, config.OutputDir, config.Options)
+				if errors.Is(err, ya.ErrTrackAlreadyExists) {
+					event.Status = StatusSkipped
+					event.Reason = "already exists"
+					event.Format = formatFromFilename(filename)
+				} else if err != nil {
+					event.Status = StatusError
+					event.Reason = err.Error()
+				} else {
+					event.Status = StatusDone
+					event.Format = formatFromFilename(filename)
+				}
+				events <- event
+			}(event)
+		}
+
+		workers.Wait()
+	}()
+
+	return events
+}
+
+func formatFromFilename(filename string) string {
+	switch strings.ToLower(filepath.Ext(filename)) {
+	case ".flac":
+		return "flac"
+	case ".m4a", ".mp4":
+		return "m4a"
+	default:
+		return "mp3"
+	}
+}

--- a/batch/download_test.go
+++ b/batch/download_test.go
@@ -1,0 +1,87 @@
+package batch
+
+import (
+	"errors"
+	"testing"
+
+	"ya-music/ya"
+	"ya-music/ya/model"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type fakeClient struct {
+	results map[string]fakeResult
+}
+
+type fakeResult struct {
+	filename string
+	err      error
+}
+
+func (c fakeClient) DownloadTrackWithOptions(track model.Track, _ string, _ ya.DownloadOptions) (string, error) {
+	result := c.results[track.ID.String()]
+	return result.filename, result.err
+}
+
+func TestRunReportsTrackLifecycleAndContinuesAfterErrors(t *testing.T) {
+	events := collect(Run(Config{
+		Client: fakeClient{results: map[string]fakeResult{
+			"1": {filename: "first.mp3"},
+			"2": {err: errors.New("access denied")},
+		}},
+		Tracks: []model.Track{
+			{ID: "1", Title: "First", Available: true},
+			{ID: "2", Title: "Second", Available: true},
+		},
+		Concurrency: 1,
+	}))
+
+	require.Len(t, events, 4)
+	assert.Equal(t, StatusDownloading, findEvent(t, events, 1, StatusDownloading).Status)
+	done := findEvent(t, events, 1, StatusDone)
+	assert.Equal(t, "mp3", done.Format)
+	assert.Equal(t, StatusDownloading, findEvent(t, events, 2, StatusDownloading).Status)
+	failed := findEvent(t, events, 2, StatusError)
+	assert.Equal(t, "access denied", failed.Reason)
+}
+
+func TestRunSkipsUnavailableDuplicatesAndExistingFiles(t *testing.T) {
+	events := collect(Run(Config{
+		Client: fakeClient{results: map[string]fakeResult{
+			"1": {filename: "first.mp3", err: ya.ErrTrackAlreadyExists},
+		}},
+		Tracks: []model.Track{
+			{ID: "1", Title: "First", Available: true},
+			{ID: "1", Title: "First", Available: true},
+			{ID: "3", Title: "Hidden", Available: false},
+		},
+		Concurrency: 1,
+	}))
+
+	require.Len(t, events, 4)
+	assert.Equal(t, StatusDownloading, findEvent(t, events, 1, StatusDownloading).Status)
+	assert.Equal(t, "duplicate", findEvent(t, events, 2, StatusSkipped).Reason)
+	assert.Equal(t, "unavailable", findEvent(t, events, 3, StatusSkipped).Reason)
+	assert.Equal(t, "already exists", findEvent(t, events, 1, StatusSkipped).Reason)
+}
+
+func collect(events <-chan Event) []Event {
+	var result []Event
+	for event := range events {
+		result = append(result, event)
+	}
+	return result
+}
+
+func findEvent(t *testing.T, events []Event, index int, status Status) Event {
+	t.Helper()
+	for _, event := range events {
+		if event.Index == index && event.Status == status {
+			return event
+		}
+	}
+	t.Fatalf("event with index %d and status %q not found in %#v", index, status, events)
+	return Event{}
+}

--- a/main.go
+++ b/main.go
@@ -1,70 +1,85 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"strings"
+	"sync/atomic"
 	"syscall"
 	"time"
+	"ya-music/batch"
 	"ya-music/ui"
 	"ya-music/utils"
 	"ya-music/ya"
+	"ya-music/ya/model"
 
 	tea "charm.land/bubbletea/v2"
 )
 
-func main() {
-	var downloadTimeoutSeconds int
-	var skipCover bool
-	flag.IntVar(&downloadTimeoutSeconds, "timeout", 0, "download timeout in seconds (0 disables timeout)")
-	flag.BoolVar(&skipCover, "skip-cover", false, "skip downloading and embedding track cover images")
-	flag.Parse()
+const defaultOutputDir = "./downloads"
 
-	if downloadTimeoutSeconds < 0 {
-		fmt.Fprintln(os.Stderr, "timeout must be >= 0 seconds")
-		os.Exit(2)
+type tuiOptions struct {
+	downloadTimeoutSeconds int
+	skipCover              bool
+}
+
+type downloadOptions struct {
+	token                  string
+	link                   string
+	format                 ya.AudioFormat
+	output                 string
+	downloadTimeoutSeconds int
+	skipCover              bool
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "download" {
+		return runDownload(args[1:], stdout, stderr)
+	}
+	return runTUI(args, stderr)
+}
+
+func runTUI(args []string, stderr io.Writer) int {
+	options, exitCode := parseTUIOptions(args, stderr)
+	if exitCode >= 0 {
+		return exitCode
 	}
 
 	if isKnownProblematicTerm(os.Getenv("TERM")) {
-		fmt.Fprintln(os.Stderr, problematicTermWarning(os.Getenv("TERM")))
-		os.Exit(2)
+		fmt.Fprintln(stderr, problematicTermWarning(os.Getenv("TERM")))
+		return 2
 	}
 
-	downloadLogger, err := utils.NewDownloadLogger(utils.DefaultDownloadLogPath)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "failed to initialize download logger: %v\n", err)
-		downloadLogger = utils.NewDiscardDownloadLogger()
-	}
+	downloadLogger := newDownloadLogger(stderr)
 	defer downloadLogger.Close()
-
-	if err := downloadLogger.Reset(); err != nil {
-		fmt.Fprintf(os.Stderr, "failed to reset download log file: %v\n", err)
-	}
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
 	httpClient := utils.NewHttpClientWithLogger(downloadLogger)
-	httpClient.SetDownloadTimeout(time.Duration(downloadTimeoutSeconds) * time.Second)
-
+	httpClient.SetDownloadTimeout(time.Duration(options.downloadTimeoutSeconds) * time.Second)
 	client := ya.NewClient(httpClient)
-	downloadOptions := ya.DownloadOptions{SkipCover: skipCover}
+	downloadOptions := ya.DownloadOptions{SkipCover: options.skipCover}
 	prog := tea.NewProgram(ui.StartUi(client, downloadOptions))
 
 	go func() {
 		sig := <-sigCh
-		prog.Send(ui.ShutdownRequestedMsg{
-			Reason: "signal_" + strings.ToLower(sig.String()),
-		})
+		prog.Send(ui.ShutdownRequestedMsg{Reason: "signal_" + strings.ToLower(sig.String())})
 	}()
 
 	downloadLogger.Info("application started",
 		"log_path", downloadLogger.Path(),
-		"download_timeout_seconds", downloadTimeoutSeconds,
-		"skip_cover", skipCover,
+		"download_timeout_seconds", options.downloadTimeoutSeconds,
+		"skip_cover", options.skipCover,
 	)
 
 	if os.Getenv("DEBUG") != "" {
@@ -72,13 +87,269 @@ func main() {
 	}
 
 	if _, err := prog.Run(); err != nil {
-		downloadLogger.Error("application terminated with error",
-			"error", err,
-		)
-		os.Exit(1)
+		downloadLogger.Error("application terminated with error", "error", err)
+		return 1
 	}
 
 	downloadLogger.Info("application stopped")
+	return 0
+}
+
+func parseTUIOptions(args []string, stderr io.Writer) (tuiOptions, int) {
+	options := tuiOptions{}
+	flags := flag.NewFlagSet("yamdl", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.IntVar(&options.downloadTimeoutSeconds, "timeout", 0, "download timeout in seconds (0 disables timeout)")
+	flags.BoolVar(&options.skipCover, "skip-cover", false, "skip downloading and embedding track cover images")
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return tuiOptions{}, 0
+		}
+		return tuiOptions{}, 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "unexpected command; use 'yamdl download --help' for batch downloads")
+		return tuiOptions{}, 2
+	}
+	if options.downloadTimeoutSeconds < 0 {
+		fmt.Fprintln(stderr, "timeout must be >= 0 seconds")
+		return tuiOptions{}, 2
+	}
+	return options, -1
+}
+
+func runDownload(args []string, stdout, stderr io.Writer) int {
+	options, exitCode := parseDownloadOptions(args, stderr)
+	if exitCode >= 0 {
+		return exitCode
+	}
+
+	downloadLogger := newDownloadLogger(stderr)
+	defer downloadLogger.Close()
+	httpClient := utils.NewHttpClientWithLogger(downloadLogger)
+	httpClient.SetDownloadTimeout(time.Duration(options.downloadTimeoutSeconds) * time.Second)
+	client := ya.NewClient(httpClient)
+	client.SetToken(options.token)
+
+	account, err := client.AccountStatus()
+	if err != nil || account.Uid == 0 {
+		if err == nil {
+			err = errors.New("account has no user ID")
+		}
+		fmt.Fprintf(stderr, "failed to validate token: %v\n", err)
+		return 1
+	}
+
+	tracks, err := ui.ResolveSourceTracks(client, options.link)
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to resolve source: %v\n", err)
+		return 1
+	}
+	if len(tracks) == 0 {
+		fmt.Fprintln(stderr, "failed to resolve source: no tracks found")
+		return 1
+	}
+	if err := utils.CreateDirIfNotExists(options.output); err != nil {
+		fmt.Fprintf(stderr, "failed to create output directory: %v\n", err)
+		return 1
+	}
+	outputInfo, err := os.Stat(options.output)
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to inspect output directory: %v\n", err)
+		return 1
+	}
+	if !outputInfo.IsDir() {
+		fmt.Fprintln(stderr, "--output must be a directory")
+		return 2
+	}
+
+	downloadLogger.Info("batch download started",
+		"source", utils.SanitizeURL(options.link),
+		"total_tracks", len(tracks),
+		"format", options.format,
+		"output", options.output,
+	)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
+	defer signal.Stop(sigCh)
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	interrupt := make(chan struct{})
+	go func() {
+		select {
+		case <-sigCh:
+			close(interrupt)
+		case <-stop:
+		}
+	}()
+
+	summary, interrupted := consumeDownloadEvents(
+		stdout,
+		batch.Run(batch.Config{
+			Client:    client,
+			Tracks:    tracks,
+			OutputDir: options.output,
+			Options: ya.DownloadOptions{
+				SkipCover:   options.skipCover,
+				AudioFormat: options.format,
+			},
+		}),
+		interrupt,
+		client.Cancel,
+	)
+
+	fmt.Fprintf(stdout, "\nFinished: %d downloaded, %d skipped, %d failed\nOutput: %s\n",
+		summary.downloaded,
+		summary.skipped,
+		summary.failed,
+		options.output,
+	)
+	downloadLogger.Info("batch download finished",
+		"downloaded", summary.downloaded,
+		"skipped", summary.skipped,
+		"failed", summary.failed,
+		"interrupted", interrupted,
+	)
+	if interrupted {
+		return 130
+	}
+	return 0
+}
+
+func parseDownloadOptions(args []string, stderr io.Writer) (downloadOptions, int) {
+	options := downloadOptions{format: ya.AudioFormatMP3, output: defaultOutputDir}
+	flags := flag.NewFlagSet("yamdl download", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	flags.StringVar(&options.token, "token", "", "Yandex Music authentication token (required)")
+	flags.StringVar(&options.link, "link", "", "Yandex Music track, album, playlist, or chart URL (required)")
+	format := string(options.format)
+	flags.StringVar(&format, "format", format, "audio format: mp3 or flac")
+	flags.StringVar(&options.output, "output", options.output, "directory for downloaded tracks")
+	flags.IntVar(&options.downloadTimeoutSeconds, "timeout", 0, "download timeout in seconds (0 disables timeout)")
+	flags.BoolVar(&options.skipCover, "skip-cover", false, "skip downloading and embedding track cover images")
+	flags.Usage = func() {
+		fmt.Fprintln(stderr, "Usage: yamdl download --token TOKEN --link URL [options]")
+		flags.PrintDefaults()
+	}
+	if err := flags.Parse(args); err != nil {
+		if errors.Is(err, flag.ErrHelp) {
+			return downloadOptions{}, 0
+		}
+		return downloadOptions{}, 2
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "download does not accept positional arguments")
+		return downloadOptions{}, 2
+	}
+	if strings.TrimSpace(options.token) == "" {
+		fmt.Fprintln(stderr, "--token is required")
+		return downloadOptions{}, 2
+	}
+	if strings.TrimSpace(options.link) == "" {
+		fmt.Fprintln(stderr, "--link is required")
+		return downloadOptions{}, 2
+	}
+	if options.downloadTimeoutSeconds < 0 {
+		fmt.Fprintln(stderr, "timeout must be >= 0 seconds")
+		return downloadOptions{}, 2
+	}
+	options.format = ya.AudioFormat(strings.ToLower(strings.TrimSpace(format)))
+	if options.format != ya.AudioFormatMP3 && options.format != ya.AudioFormatFLAC {
+		fmt.Fprintln(stderr, "--format must be mp3 or flac")
+		return downloadOptions{}, 2
+	}
+	options.output = strings.TrimSpace(options.output)
+	if options.output == "" {
+		fmt.Fprintln(stderr, "--output must not be empty")
+		return downloadOptions{}, 2
+	}
+	options.token = strings.TrimSpace(options.token)
+	options.link = strings.TrimSpace(options.link)
+	return options, -1
+}
+
+type batchSummary struct {
+	downloaded int
+	skipped    int
+	failed     int
+}
+
+func (s *batchSummary) add(event batch.Event) {
+	switch event.Status {
+	case batch.StatusDone:
+		s.downloaded++
+	case batch.StatusSkipped:
+		s.skipped++
+	case batch.StatusError:
+		s.failed++
+	}
+}
+
+func consumeDownloadEvents(
+	stdout io.Writer,
+	events <-chan batch.Event,
+	interrupt <-chan struct{},
+	cancel func(),
+) (summary batchSummary, interrupted bool) {
+	var interruptedFlag atomic.Bool
+
+	if interrupt != nil && cancel != nil {
+		go func() {
+			<-interrupt
+			interruptedFlag.Store(true)
+			cancel()
+		}()
+	}
+
+	for event := range events {
+		fmt.Fprintln(stdout, formatBatchEvent(event))
+		summary.add(event)
+	}
+
+	return summary, interruptedFlag.Load()
+}
+
+func formatBatchEvent(event batch.Event) string {
+	label := formatTrackLabel(event.Track)
+	switch event.Status {
+	case batch.StatusDownloading:
+		return fmt.Sprintf("%3d. %s — downloading", event.Index, label)
+	case batch.StatusDone:
+		return fmt.Sprintf("%3d. %s — done (%s)", event.Index, label, event.Format)
+	case batch.StatusSkipped:
+		return fmt.Sprintf("%3d. %s — skipped: %s", event.Index, label, event.Reason)
+	case batch.StatusError:
+		return fmt.Sprintf("%3d. %s — error: %s", event.Index, label, event.Reason)
+	default:
+		return fmt.Sprintf("%3d. %s — %s", event.Index, label, event.Status)
+	}
+}
+
+func formatTrackLabel(track model.Track) string {
+	title := strings.TrimSpace(track.FullTitle())
+	artists := strings.TrimSpace(track.ArtistsString())
+	if artists == "" {
+		return title
+	}
+	if title == "" {
+		return artists
+	}
+	return artists + " — " + title
+}
+
+func newDownloadLogger(stderr io.Writer) *utils.DownloadLogger {
+	downloadLogger, err := utils.NewDownloadLogger(utils.DefaultDownloadLogPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "failed to initialize download logger: %v\n", err)
+		downloadLogger = utils.NewDiscardDownloadLogger()
+	}
+	if err := downloadLogger.Reset(); err != nil {
+		fmt.Fprintf(stderr, "failed to reset download log file: %v\n", err)
+	}
+	return downloadLogger
 }
 
 func isKnownProblematicTerm(term string) bool {

--- a/main_test.go
+++ b/main_test.go
@@ -1,8 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"strings"
 	"testing"
+	"ya-music/batch"
+	"ya-music/ya"
+	"ya-music/ya/model"
 )
 
 func TestIsKnownProblematicTerm(t *testing.T) {
@@ -27,6 +31,64 @@ func TestIsKnownProblematicTerm(t *testing.T) {
 	}
 }
 
+func TestParseDownloadOptionsAcceptsCurrentDownloadFlags(t *testing.T) {
+	var stderr bytes.Buffer
+	options, exitCode := parseDownloadOptions([]string{
+		"--token", "  abc123  ",
+		"--link", "  https://music.yandex.ru/album/123  ",
+		"--format", "FLAC",
+		"--output", "./music",
+		"--timeout", "180",
+		"--skip-cover",
+	}, &stderr)
+
+	if exitCode != -1 {
+		t.Fatalf("exit code = %d, stderr: %s", exitCode, stderr.String())
+	}
+	if options.token != "abc123" || options.link != "https://music.yandex.ru/album/123" {
+		t.Fatalf("unexpected required options: %#v", options)
+	}
+	if options.format != ya.AudioFormatFLAC || options.output != "./music" || options.downloadTimeoutSeconds != 180 || !options.skipCover {
+		t.Fatalf("unexpected parsed options: %#v", options)
+	}
+}
+
+func TestParseDownloadOptionsRejectsInvalidInput(t *testing.T) {
+	tests := [][]string{
+		{"--link", "https://music.yandex.ru/album/123"},
+		{"--token", "abc123"},
+		{"--token", "abc123", "--link", "https://music.yandex.ru/album/123", "--format", "aac"},
+		{"--token", "abc123", "--link", "https://music.yandex.ru/album/123", "--timeout", "-1"},
+	}
+
+	for _, args := range tests {
+		var stderr bytes.Buffer
+		_, exitCode := parseDownloadOptions(args, &stderr)
+		if exitCode != 2 {
+			t.Fatalf("args %q: exit code = %d, stderr: %s", args, exitCode, stderr.String())
+		}
+	}
+}
+
+func TestFormatBatchEventAndSummary(t *testing.T) {
+	track := model.Track{
+		Title:   "Track",
+		Artists: []model.Artist{{Name: "Artist"}},
+	}
+	event := batch.Event{Index: 2, Track: track, Status: batch.StatusDone, Format: "m4a"}
+	if got, want := formatBatchEvent(event), "  2. Artist — Track — done (m4a)"; got != want {
+		t.Fatalf("formatBatchEvent() = %q, want %q", got, want)
+	}
+
+	summary := batchSummary{}
+	summary.add(event)
+	summary.add(batch.Event{Status: batch.StatusSkipped})
+	summary.add(batch.Event{Status: batch.StatusError})
+	if summary != (batchSummary{downloaded: 1, skipped: 1, failed: 1}) {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+}
+
 func TestProblematicTermWarning(t *testing.T) {
 	warning := problematicTermWarning("xterm")
 
@@ -38,5 +100,61 @@ func TestProblematicTermWarning(t *testing.T) {
 		if !strings.Contains(warning, want) {
 			t.Fatalf("warning does not contain %q:\n%s", want, warning)
 		}
+	}
+}
+
+func TestConsumeDownloadEventsDrainsAllEventsWithoutInterrupt(t *testing.T) {
+	events := make(chan batch.Event, 3)
+	events <- batch.Event{Index: 1, Status: batch.StatusDone}
+	events <- batch.Event{Index: 2, Status: batch.StatusSkipped}
+	events <- batch.Event{Index: 3, Status: batch.StatusError}
+	close(events)
+
+	var stdout bytes.Buffer
+	cancelCalled := false
+	summary, interrupted := consumeDownloadEvents(&stdout, events, make(chan struct{}), func() {
+		cancelCalled = true
+	})
+
+	if interrupted {
+		t.Fatal("expected interrupted = false")
+	}
+	if cancelCalled {
+		t.Fatal("cancel should not be called without interrupt")
+	}
+	if summary != (batchSummary{downloaded: 1, skipped: 1, failed: 1}) {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	if strings.Count(stdout.String(), "\n") != 3 {
+		t.Fatalf("expected 3 event lines, got:\n%s", stdout.String())
+	}
+}
+
+func TestConsumeDownloadEventsCallsCancelAndDrainsOnInterrupt(t *testing.T) {
+	events := make(chan batch.Event)
+	interrupt := make(chan struct{})
+
+	go func() {
+		events <- batch.Event{Index: 1, Status: batch.StatusDownloading}
+		close(interrupt)
+		events <- batch.Event{Index: 1, Status: batch.StatusDone}
+		events <- batch.Event{Index: 2, Status: batch.StatusError}
+		close(events)
+	}()
+
+	var stdout bytes.Buffer
+	cancelCalled := false
+	summary, interrupted := consumeDownloadEvents(&stdout, events, interrupt, func() {
+		cancelCalled = true
+	})
+
+	if !interrupted {
+		t.Fatal("expected interrupted = true")
+	}
+	if !cancelCalled {
+		t.Fatal("cancel should be called on interrupt")
+	}
+	if summary.downloaded != 1 || summary.failed != 1 {
+		t.Fatalf("unexpected summary: %#v", summary)
 	}
 }

--- a/ui/source.go
+++ b/ui/source.go
@@ -44,9 +44,7 @@ type (
 	}
 
 	SourceSubmitMsg struct {
-		Playlist *model.Playlist
-		Album    *model.Album
-		Track    *model.Track
+		Tracks []model.Track
 	}
 
 	URLHandleErrorMsg string
@@ -145,20 +143,28 @@ func (m SourceModel) handleEnterKey() (SourceModel, tea.Cmd) {
 }
 
 func (m *SourceModel) parseURL(input string) tea.Msg {
+	msg := parseSourceURL(input)
+	if msg == nil {
+		return nil
+	}
+	return *msg
+}
+
+func parseSourceURL(input string) *URLSubmitMsg {
 	if matches := trackPattern.FindStringSubmatch(input); matches != nil {
-		return URLSubmitMsg{
+		return &URLSubmitMsg{
 			kind:    sourceURLTrack,
 			TrackID: matches[2],
 		}
 	}
 	if matches := albumPattern.FindStringSubmatch(input); matches != nil {
-		return URLSubmitMsg{
+		return &URLSubmitMsg{
 			kind:    sourceURLAlbum,
 			AlbumID: matches[1],
 		}
 	}
 	if matches := playlistPattern.FindStringSubmatch(input); matches != nil {
-		return URLSubmitMsg{
+		return &URLSubmitMsg{
 			kind:       sourceURLLegacyPlaylist,
 			PlaylistID: matches[2],
 			Username:   matches[1],
@@ -177,13 +183,13 @@ func (m *SourceModel) parseURL(input string) tea.Msg {
 			return nil
 		}
 
-		return URLSubmitMsg{
+		return &URLSubmitMsg{
 			kind:         sourceURLPlaylistUUID,
 			PlaylistUUID: playlistID,
 		}
 	}
 	if matches := chartPattern.FindStringSubmatch(input); matches != nil {
-		return URLSubmitMsg{
+		return &URLSubmitMsg{
 			kind:   sourceURLChart,
 			Region: matches[1],
 		}
@@ -193,46 +199,79 @@ func (m *SourceModel) parseURL(input string) tea.Msg {
 
 func (m *SourceModel) handleURL(msg URLSubmitMsg) tea.Cmd {
 	return func() tea.Msg {
-		switch msg.kind {
-		case sourceURLTrack:
-			track, err := m.client.TrackInfo(msg.TrackID)
-			if err != nil {
-				return URLHandleErrorMsg(err.Error())
-			}
-			return SourceSubmitMsg{Track: track}
-		case sourceURLAlbum:
-			album, err := m.client.AlbumWithTracks(msg.AlbumID)
-			if err != nil {
-				return URLHandleErrorMsg(err.Error())
-			}
-			return SourceSubmitMsg{Album: album}
-		case sourceURLLegacyPlaylist, sourceURLPlaylistUUID:
-			playlist, err := m.fetchPlaylist(msg)
-			if err != nil {
-				return URLHandleErrorMsg(err.Error())
-			}
-			return SourceSubmitMsg{Playlist: playlist}
-		case sourceURLChart:
-			playlist, err := m.client.Chart(msg.Region)
-			if err != nil {
-				return URLHandleErrorMsg(err.Error())
-			}
-			return SourceSubmitMsg{Playlist: playlist}
-		default:
-			return URLHandleErrorMsg("unsupported url type")
+		tracks, err := resolveSourceTracks(m.client, msg)
+		if err != nil {
+			return URLHandleErrorMsg(err.Error())
 		}
+		return SourceSubmitMsg{Tracks: tracks}
 	}
 }
 
-func (m *SourceModel) fetchPlaylist(msg URLSubmitMsg) (*model.Playlist, error) {
-	switch msg.kind {
-	case sourceURLLegacyPlaylist:
-		return m.client.UsersPlaylist(msg.PlaylistID, msg.Username)
-	case sourceURLPlaylistUUID:
-		return m.client.PlaylistByUUID(msg.PlaylistUUID)
-	default:
-		return nil, fmt.Errorf("unsupported playlist url type")
+type sourceClient interface {
+	TrackInfo(id string) (*model.Track, error)
+	AlbumWithTracks(id string) (*model.Album, error)
+	UsersPlaylist(id string, username string) (*model.Playlist, error)
+	PlaylistByUUID(id string) (*model.Playlist, error)
+	Chart(region string) (*model.Playlist, error)
+}
+
+// ResolveSourceTracks turns a supported Yandex Music URL into its tracks.
+// Both the terminal UI and the non-interactive command use this resolver.
+func ResolveSourceTracks(client sourceClient, input string) ([]model.Track, error) {
+	msg := parseSourceURL(strings.TrimSpace(input))
+	if msg == nil {
+		return nil, fmt.Errorf("invalid URL")
 	}
+	return resolveSourceTracks(client, *msg)
+}
+
+func resolveSourceTracks(client sourceClient, msg URLSubmitMsg) ([]model.Track, error) {
+	switch msg.kind {
+	case sourceURLTrack:
+		track, err := client.TrackInfo(msg.TrackID)
+		if err != nil {
+			return nil, err
+		}
+		return []model.Track{*track}, nil
+	case sourceURLAlbum:
+		album, err := client.AlbumWithTracks(msg.AlbumID)
+		if err != nil {
+			return nil, err
+		}
+		var tracks []model.Track
+		for _, volume := range album.Volumes {
+			tracks = append(tracks, volume...)
+		}
+		return tracks, nil
+	case sourceURLLegacyPlaylist:
+		playlist, err := client.UsersPlaylist(msg.PlaylistID, msg.Username)
+		if err != nil {
+			return nil, err
+		}
+		return playlistTracks(playlist), nil
+	case sourceURLPlaylistUUID:
+		playlist, err := client.PlaylistByUUID(msg.PlaylistUUID)
+		if err != nil {
+			return nil, err
+		}
+		return playlistTracks(playlist), nil
+	case sourceURLChart:
+		playlist, err := client.Chart(msg.Region)
+		if err != nil {
+			return nil, err
+		}
+		return playlistTracks(playlist), nil
+	default:
+		return nil, fmt.Errorf("unsupported URL type")
+	}
+}
+
+func playlistTracks(playlist *model.Playlist) []model.Track {
+	tracks := make([]model.Track, 0, len(playlist.Tracks))
+	for _, short := range playlist.Tracks {
+		tracks = append(tracks, short.Track)
+	}
+	return tracks
 }
 
 func (m SourceModel) View() tea.View {

--- a/ui/source_test.go
+++ b/ui/source_test.go
@@ -1,10 +1,14 @@
 package ui
 
 import (
+	"errors"
 	"testing"
+
+	"ya-music/ya/model"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestSourceParseURLTrack(t *testing.T) {
@@ -155,4 +159,130 @@ func TestSourceResizeKeepsMinimumURLInputWidth(t *testing.T) {
 	m.Resize(10, 40)
 
 	assert.Equal(t, minInputWidth, m.urlInput.Width())
+}
+
+type fakeSourceClient struct {
+	track              *model.Track
+	trackErr           error
+	album              *model.Album
+	albumErr           error
+	legacyPlaylist     *model.Playlist
+	legacyPlaylistErr  error
+	uuidPlaylist       *model.Playlist
+	uuidPlaylistErr    error
+	chart              *model.Playlist
+	chartErr           error
+}
+
+func (f fakeSourceClient) TrackInfo(string) (*model.Track, error) {
+	return f.track, f.trackErr
+}
+
+func (f fakeSourceClient) AlbumWithTracks(string) (*model.Album, error) {
+	return f.album, f.albumErr
+}
+
+func (f fakeSourceClient) UsersPlaylist(string, string) (*model.Playlist, error) {
+	return f.legacyPlaylist, f.legacyPlaylistErr
+}
+
+func (f fakeSourceClient) PlaylistByUUID(string) (*model.Playlist, error) {
+	return f.uuidPlaylist, f.uuidPlaylistErr
+}
+
+func (f fakeSourceClient) Chart(string) (*model.Playlist, error) {
+	return f.chart, f.chartErr
+}
+
+func TestResolveSourceTracksAlbumFlattensVolumes(t *testing.T) {
+	client := fakeSourceClient{
+		album: &model.Album{
+			Volumes: [][]model.Track{
+				{{ID: model.FlexibleID("1"), Title: "A"}},
+				{{ID: model.FlexibleID("2"), Title: "B"}},
+			},
+		},
+	}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/album/123")
+	require.NoError(t, err)
+	require.Len(t, tracks, 2)
+	assert.Equal(t, "1", tracks[0].ID.String())
+	assert.Equal(t, "2", tracks[1].ID.String())
+}
+
+func TestResolveSourceTracksLegacyPlaylistExtractsTracks(t *testing.T) {
+	client := fakeSourceClient{
+		legacyPlaylist: &model.Playlist{
+			Tracks: []model.TrackShort{
+				{Track: model.Track{ID: model.FlexibleID("10"), Title: "One"}},
+			},
+		},
+	}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/users/user/playlists/99")
+	require.NoError(t, err)
+	require.Len(t, tracks, 1)
+	assert.Equal(t, "10", tracks[0].ID.String())
+}
+
+func TestResolveSourceTracksUUIDPlaylistExtractsTracks(t *testing.T) {
+	playlistUUID := uuid.NewString()
+	client := fakeSourceClient{
+		uuidPlaylist: &model.Playlist{
+			Tracks: []model.TrackShort{
+				{Track: model.Track{ID: model.FlexibleID("20"), Title: "Two"}},
+			},
+		},
+	}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/playlists/"+playlistUUID)
+	require.NoError(t, err)
+	require.Len(t, tracks, 1)
+	assert.Equal(t, "20", tracks[0].ID.String())
+}
+
+func TestResolveSourceTracksChartExtractsTracks(t *testing.T) {
+	client := fakeSourceClient{
+		chart: &model.Playlist{
+			Tracks: []model.TrackShort{
+				{Track: model.Track{ID: model.FlexibleID("30"), Title: "Chart hit"}},
+			},
+		},
+	}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/chart/world")
+	require.NoError(t, err)
+	require.Len(t, tracks, 1)
+	assert.Equal(t, "30", tracks[0].ID.String())
+}
+
+func TestResolveSourceTracksRejectsInvalidURL(t *testing.T) {
+	_, err := ResolveSourceTracks(fakeSourceClient{}, "not-a-url")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid URL")
+}
+
+func TestResolveSourceTracksReturnsEmptyAlbumWithoutError(t *testing.T) {
+	client := fakeSourceClient{album: &model.Album{}}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/album/123")
+	require.NoError(t, err)
+	assert.Empty(t, tracks)
+}
+
+func TestResolveSourceTracksReturnsEmptyPlaylistWithoutError(t *testing.T) {
+	client := fakeSourceClient{legacyPlaylist: &model.Playlist{}}
+
+	tracks, err := ResolveSourceTracks(client, "https://music.yandex.ru/users/user/playlists/99")
+	require.NoError(t, err)
+	assert.Empty(t, tracks)
+}
+
+func TestResolveSourceTracksPropagatesClientErrors(t *testing.T) {
+	client := fakeSourceClient{albumErr: errors.New("access denied")}
+
+	_, err := ResolveSourceTracks(client, "https://music.yandex.ru/album/123")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "access denied")
 }

--- a/ui/tui.go
+++ b/ui/tui.go
@@ -5,7 +5,6 @@ import (
 
 	"ya-music/utils"
 	"ya-music/ya"
-	"ya-music/ya/model"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -82,20 +81,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 	case SourceSubmitMsg:
 		m.initState = UiStateDownloading
-
-		var tracks []model.Track
-		if msg.Track != nil {
-			tracks = append(tracks, *msg.Track)
-		} else if msg.Album != nil {
-			for _, volume := range msg.Album.Volumes {
-				tracks = append(tracks, volume...)
-			}
-		} else if msg.Playlist != nil {
-			for _, trackShort := range msg.Playlist.Tracks {
-				tracks = append(tracks, trackShort.Track)
-			}
-		}
-		m.downloadModel.AddTracks(tracks)
+		m.downloadModel.AddTracks(msg.Tracks)
 		m.resizeToWindow()
 
 		cmds = append(cmds, m.downloadModel.Init())

--- a/ui/tui_test.go
+++ b/ui/tui_test.go
@@ -79,11 +79,11 @@ func TestSourceSubmitAppliesStoredWindowSizeToDownloadModel(t *testing.T) {
 	m.windowHeight = 30
 
 	updatedModel, _ := m.Update(SourceSubmitMsg{
-		Track: &model.Track{
+		Tracks: []model.Track{{
 			ID:        model.FlexibleID("1"),
 			Title:     "Track",
 			Available: true,
-		},
+		}},
 	})
 	updated := updatedModel.(Model)
 
@@ -110,7 +110,7 @@ func TestDownloadViewFitsInsideStoredWindowHeight(t *testing.T) {
 	}
 
 	updatedModel, _ = updated.Update(SourceSubmitMsg{
-		Album: &model.Album{Volumes: [][]model.Track{tracks}},
+		Tracks: tracks,
 	})
 	updated = updatedModel.(Model)
 
@@ -130,21 +130,15 @@ func TestBackToURLAppliesStoredWindowSizeToSourceModel(t *testing.T) {
 	assert.Equal(t, 96, updated.sourceModel.urlInput.Width())
 }
 
-func TestSourceSubmitAlbumAddsVolumeTracks(t *testing.T) {
+func TestSourceSubmitAddsTracks(t *testing.T) {
 	client := ya.NewClient(utils.NewHttpClient())
 	m := StartUi(client)
 
 	updatedModel, _ := m.Update(SourceSubmitMsg{
-		Album: &model.Album{
-			Volumes: [][]model.Track{
-				{
-					{ID: model.FlexibleID("2"), Title: "B", Available: true},
-					{ID: model.FlexibleID("1"), Title: "A", Available: true},
-				},
-				{
-					{ID: model.FlexibleID("3"), Title: "C", Available: true},
-				},
-			},
+		Tracks: []model.Track{
+			{ID: model.FlexibleID("2"), Title: "B", Available: true},
+			{ID: model.FlexibleID("1"), Title: "A", Available: true},
+			{ID: model.FlexibleID("3"), Title: "C", Available: true},
 		},
 	})
 	updated := updatedModel.(Model)


### PR DESCRIPTION
## Summary

- Add `yamdl download` subcommand for headless batch downloads of tracks, albums, playlists, and charts with `--token`, `--link`, `--format`, `--output`, `--timeout`, and `--skip-cover`
- Introduce `batch` package with concurrent download runner and lifecycle events; share URL resolution via `ui.ResolveSourceTracks`
- Handle Ctrl+C/SIGTERM in batch mode (cancel in-flight downloads, print summary, exit 130); per-track failures do not fail the command (exit 0)

## Test plan

- [x] `go test ./...`
- [x] `./yamdl download --token TOKEN --link https://music.yandex.ru/album/ID --output ./downloads`
- [x] Verify duplicate/unavailable/already-exists tracks appear as skipped in output
- [x] Interrupt a long batch with Ctrl+C and confirm summary + exit code 130
- [x] Confirm `./yamdl` TUI still starts and resolves URLs as before