### PR TITLE
Fix batch download progress and interrupt handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.13.1 - 2026-08-20
+- append each batch-download status as an immutable `[status] Artist — Track` line so previous events stay visible and are never overwritten
+- stop scheduling remaining batch tracks on Ctrl+C or SIGTERM so cancelled tracks stay queued, print `Interrupted: remaining tracks stayed queued`, then still emit the partial summary and exit 130
+
 ## v1.13 - 2026-08-19
 - added a non-interactive `yamdl download` command for downloading a track, album, playlist, or chart without opening the terminal UI
 - added required `--token` and `--link` options plus `--format`, `--output`, `--timeout`, and `--skip-cover` controls for batch downloads; MP3 and `./downloads` remain the defaults

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Available options:
 - `--timeout <seconds>` limits the download time for each audio file. Use `0`, the default, to disable the limit.
 - `--skip-cover` skips downloading and embedding cover art. Text metadata is still written.
 
-During the download, each track event is appended to stdout as it happens. A track first prints `[downloading] Artist — Track title`, then a final line such as `[done] Artist — Track title` or `[already exists] Artist — Track title`. Previous lines are never cleared or overwritten.
+During the download, each track event is appended to stdout as it happens. A track first prints `[downloading] Artist — Track title`, then a final line such as `[done] Artist — Track title` or `[already exists] Artist — Track title`. Previous lines are never cleared or overwritten. Press `Ctrl+C` to stop scheduling remaining tracks: in-flight downloads can still finish, then the command prints `Interrupted: remaining tracks stayed queued` followed by the partial summary and exits with code 130.
 
 ```text
 [downloading] Artist — Track title

--- a/README.md
+++ b/README.md
@@ -55,13 +55,13 @@ Available options:
 - `--timeout <seconds>` limits the download time for each audio file. Use `0`, the default, to disable the limit.
 - `--skip-cover` skips downloading and embedding cover art. Text metadata is still written.
 
-Each status update includes the track's source position. A track is reported when downloading starts and again when it finishes, for example:
+During the download, each track event is appended to stdout as it happens. A track first prints `[downloading] Artist — Track title`, then a final line such as `[done] Artist — Track title` or `[already exists] Artist — Track title`. Previous lines are never cleared or overwritten.
 
 ```text
-  1. Artist — Track title — downloading
-  2. Artist — Another track — skipped: already exists
-  3. Artist — Restricted track — skipped: unavailable
-  1. Artist — Track title — done (mp3)
+[downloading] Artist — Track title
+[done] Artist — Track title
+[already exists] Artist — Another track
+[unavailable] Artist — Restricted track
 
 Finished: 1 downloaded, 2 skipped, 0 failed
 Output: ./downloads

--- a/batch/download.go
+++ b/batch/download.go
@@ -1,6 +1,7 @@
 package batch
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -40,11 +41,16 @@ type Config struct {
 	OutputDir   string
 	Options     ya.DownloadOptions
 	Concurrency int
+	Context     context.Context
 }
 
 // Run downloads all eligible tracks and reports immutable lifecycle events.
 func Run(config Config) <-chan Event {
 	events := make(chan Event)
+	ctx := config.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	concurrency := config.Concurrency
 	if concurrency <= 0 {
 		concurrency = DefaultConcurrency
@@ -59,6 +65,10 @@ func Run(config Config) <-chan Event {
 		var workers sync.WaitGroup
 
 		for position, track := range config.Tracks {
+			if ctx.Err() != nil {
+				break
+			}
+
 			event := Event{Index: position + 1, Track: track}
 			if !track.Available {
 				event.Status = StatusSkipped
@@ -84,9 +94,20 @@ func Run(config Config) <-chan Event {
 			seenIDs[id] = struct{}{}
 			seenNames[name] = struct{}{}
 
+			acquired := false
+			select {
+			case sem <- struct{}{}:
+				acquired = true
+			case <-ctx.Done():
+			}
+			if !acquired {
+				break
+			}
+
 			workers.Add(1)
 			go func(event Event) {
 				defer workers.Done()
+				defer func() { <-sem }()
 				defer func() {
 					if recovered := recover(); recovered != nil {
 						event.Status = StatusError
@@ -95,8 +116,9 @@ func Run(config Config) <-chan Event {
 					}
 				}()
 
-				sem <- struct{}{}
-				defer func() { <-sem }()
+				if ctx.Err() != nil {
+					return
+				}
 
 				event.Status = StatusDownloading
 				events <- event

--- a/batch/download_test.go
+++ b/batch/download_test.go
@@ -1,7 +1,9 @@
 package batch
 
 import (
+	"context"
 	"errors"
+	"sync"
 	"testing"
 
 	"ya-music/ya"
@@ -65,6 +67,60 @@ func TestRunSkipsUnavailableDuplicatesAndExistingFiles(t *testing.T) {
 	assert.Equal(t, "duplicate", findEvent(t, events, 2, StatusSkipped).Reason)
 	assert.Equal(t, "unavailable", findEvent(t, events, 3, StatusSkipped).Reason)
 	assert.Equal(t, "already exists", findEvent(t, events, 1, StatusSkipped).Reason)
+}
+
+type blockingClient struct {
+	started chan string
+	release chan struct{}
+	mu      sync.Mutex
+	called  []string
+}
+
+func (c *blockingClient) DownloadTrackWithOptions(track model.Track, _ string, _ ya.DownloadOptions) (string, error) {
+	c.mu.Lock()
+	c.called = append(c.called, track.ID.String())
+	c.mu.Unlock()
+	c.started <- track.ID.String()
+	<-c.release
+	return track.ID.String() + ".mp3", nil
+}
+
+func (c *blockingClient) calls() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.called...)
+}
+
+func TestRunStopsSchedulingTracksWhenContextIsCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	client := &blockingClient{
+		started: make(chan string, 1),
+		release: make(chan struct{}),
+	}
+
+	events := Run(Config{
+		Client: client,
+		Tracks: []model.Track{
+			{ID: "1", Title: "First", Available: true},
+			{ID: "2", Title: "Second", Available: true},
+		},
+		Concurrency: 1,
+		Context:     ctx,
+	})
+
+	first := <-events
+	assert.Equal(t, Event{Index: 1, Track: model.Track{ID: "1", Title: "First", Available: true}, Status: StatusDownloading}, first)
+	assert.Equal(t, "1", <-client.started)
+
+	cancel()
+	close(client.release)
+
+	remaining := collect(events)
+	assert.Len(t, remaining, 1)
+	assert.Equal(t, StatusDone, remaining[0].Status)
+	assert.Equal(t, 1, remaining[0].Index)
+	assert.Equal(t, []string{"1"}, client.calls())
 }
 
 func collect(events <-chan Event) []Event {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	charm.land/lipgloss/v2 v2.0.3
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/charmbracelet/harmonica v0.2.0 // indirect
-	github.com/charmbracelet/x/term v0.2.2 // indirect
+	github.com/charmbracelet/x/term v0.2.2
 	github.com/clipperhouse/displaywidth v0.11.0 // indirect
 	github.com/clipperhouse/uax29/v2 v2.7.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"flag"
 	"fmt"
@@ -8,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"sync/atomic"
 	"syscall"
 	"time"
 	"ya-music/batch"
@@ -174,17 +174,19 @@ func runDownload(args []string, stdout, stderr io.Writer) int {
 	signal.Notify(sigCh, os.Interrupt, syscall.SIGTERM)
 	defer signal.Stop(sigCh)
 
-	stop := make(chan struct{})
-	defer close(stop)
+	signalStop := make(chan struct{})
+	defer close(signalStop)
 
 	interrupt := make(chan struct{})
 	go func() {
 		select {
 		case <-sigCh:
 			close(interrupt)
-		case <-stop:
+		case <-signalStop:
 		}
 	}()
+	batchContext, cancelBatch := context.WithCancel(context.Background())
+	defer cancelBatch()
 
 	summary, interrupted := consumeDownloadEvents(
 		stdout,
@@ -192,13 +194,17 @@ func runDownload(args []string, stdout, stderr io.Writer) int {
 			Client:    client,
 			Tracks:    tracks,
 			OutputDir: options.output,
+			Context:   batchContext,
 			Options: ya.DownloadOptions{
 				SkipCover:   options.skipCover,
 				AudioFormat: options.format,
 			},
 		}),
 		interrupt,
-		client.Cancel,
+		func() {
+			cancelBatch()
+			client.Cancel()
+		},
 	)
 
 	fmt.Fprintf(stdout, "\nFinished: %d downloaded, %d skipped, %d failed\nOutput: %s\n",
@@ -294,38 +300,56 @@ func consumeDownloadEvents(
 	interrupt <-chan struct{},
 	cancel func(),
 ) (summary batchSummary, interrupted bool) {
-	var interruptedFlag atomic.Bool
+	for events != nil {
+		if interrupt == nil {
+			event, ok := <-events
+			if !ok {
+				break
+			}
+			fmt.Fprintln(stdout, formatBatchEvent(event))
+			summary.add(event)
+			continue
+		}
 
-	if interrupt != nil && cancel != nil {
-		go func() {
-			<-interrupt
-			interruptedFlag.Store(true)
-			cancel()
-		}()
+		select {
+		case <-interrupt:
+			interrupted = true
+			interrupt = nil
+			if cancel != nil {
+				cancel()
+			}
+		case event, ok := <-events:
+			if !ok {
+				select {
+				case <-interrupt:
+					interrupted = true
+					if cancel != nil {
+						cancel()
+					}
+				default:
+				}
+				events = nil
+				continue
+			}
+			fmt.Fprintln(stdout, formatBatchEvent(event))
+			summary.add(event)
+		}
 	}
 
-	for event := range events {
-		fmt.Fprintln(stdout, formatBatchEvent(event))
-		summary.add(event)
+	if interrupted {
+		fmt.Fprintln(stdout, "Interrupted: remaining tracks stayed queued")
 	}
-
-	return summary, interruptedFlag.Load()
+	return summary, interrupted
 }
 
 func formatBatchEvent(event batch.Event) string {
-	label := formatTrackLabel(event.Track)
-	switch event.Status {
-	case batch.StatusDownloading:
-		return fmt.Sprintf("%3d. %s — downloading", event.Index, label)
-	case batch.StatusDone:
-		return fmt.Sprintf("%3d. %s — done (%s)", event.Index, label, event.Format)
-	case batch.StatusSkipped:
-		return fmt.Sprintf("%3d. %s — skipped: %s", event.Index, label, event.Reason)
-	case batch.StatusError:
-		return fmt.Sprintf("%3d. %s — error: %s", event.Index, label, event.Reason)
-	default:
-		return fmt.Sprintf("%3d. %s — %s", event.Index, label, event.Status)
+	status := string(event.Status)
+	if event.Status == batch.StatusSkipped {
+		if reason := strings.TrimSpace(event.Reason); reason != "" {
+			status = reason
+		}
 	}
+	return fmt.Sprintf("[%s] %s", status, formatTrackLabel(event.Track))
 }
 
 func formatTrackLabel(track model.Track) string {

--- a/main_test.go
+++ b/main_test.go
@@ -76,8 +76,21 @@ func TestFormatBatchEventAndSummary(t *testing.T) {
 		Artists: []model.Artist{{Name: "Artist"}},
 	}
 	event := batch.Event{Index: 2, Track: track, Status: batch.StatusDone, Format: "m4a"}
-	if got, want := formatBatchEvent(event), "  2. Artist — Track — done (m4a)"; got != want {
-		t.Fatalf("formatBatchEvent() = %q, want %q", got, want)
+	tests := []struct {
+		event batch.Event
+		want  string
+	}{
+		{event: event, want: "[done] Artist — Track"},
+		{event: batch.Event{Track: track, Status: batch.StatusDownloading}, want: "[downloading] Artist — Track"},
+		{event: batch.Event{Track: track, Status: batch.StatusSkipped, Reason: "already exists"}, want: "[already exists] Artist — Track"},
+		{event: batch.Event{Track: track, Status: batch.StatusSkipped, Reason: "unavailable"}, want: "[unavailable] Artist — Track"},
+		{event: batch.Event{Track: track, Status: batch.StatusSkipped, Reason: "duplicate"}, want: "[duplicate] Artist — Track"},
+		{event: batch.Event{Track: track, Status: batch.StatusError, Reason: "access denied"}, want: "[error] Artist — Track"},
+	}
+	for _, tt := range tests {
+		if got := formatBatchEvent(tt.event); got != tt.want {
+			t.Fatalf("formatBatchEvent() = %q, want %q", got, tt.want)
+		}
 	}
 
 	summary := batchSummary{}
@@ -86,6 +99,38 @@ func TestFormatBatchEventAndSummary(t *testing.T) {
 	summary.add(batch.Event{Status: batch.StatusError})
 	if summary != (batchSummary{downloaded: 1, skipped: 1, failed: 1}) {
 		t.Fatalf("unexpected summary: %#v", summary)
+	}
+}
+
+func TestConsumeDownloadEventsWritesEventsAsTheyArrive(t *testing.T) {
+	tracks := []model.Track{
+		{Title: "First", Artists: []model.Artist{{Name: "One"}}},
+		{Title: "Second", Artists: []model.Artist{{Name: "Two"}}},
+	}
+	events := make(chan batch.Event, 3)
+	events <- batch.Event{Index: 2, Track: tracks[1], Status: batch.StatusDownloading}
+	events <- batch.Event{Index: 2, Track: tracks[1], Status: batch.StatusDone, Format: "mp3"}
+	events <- batch.Event{Index: 1, Track: tracks[0], Status: batch.StatusDone, Format: "flac"}
+	close(events)
+
+	var stdout bytes.Buffer
+	summary, interrupted := consumeDownloadEvents(&stdout, events, nil, nil)
+
+	if interrupted {
+		t.Fatal("expected interrupted = false")
+	}
+	if summary != (batchSummary{downloaded: 2}) {
+		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	if got, want := stdout.String(), strings.Join([]string{
+		"[downloading] Two — Second",
+		"[done] Two — Second",
+		"[done] One — First",
+	}, "\n")+"\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
+	}
+	if strings.Contains(stdout.String(), "\x1b") {
+		t.Fatalf("output contains ANSI escape sequence: %q", stdout.String())
 	}
 }
 
@@ -104,10 +149,15 @@ func TestProblematicTermWarning(t *testing.T) {
 }
 
 func TestConsumeDownloadEventsDrainsAllEventsWithoutInterrupt(t *testing.T) {
+	tracks := []model.Track{
+		{Title: "First", Artists: []model.Artist{{Name: "One"}}},
+		{Title: "Second", Artists: []model.Artist{{Name: "Two"}}},
+		{Title: "Third", Artists: []model.Artist{{Name: "Three"}}},
+	}
 	events := make(chan batch.Event, 3)
-	events <- batch.Event{Index: 1, Status: batch.StatusDone}
-	events <- batch.Event{Index: 2, Status: batch.StatusSkipped}
-	events <- batch.Event{Index: 3, Status: batch.StatusError}
+	events <- batch.Event{Index: 1, Track: tracks[0], Status: batch.StatusDone, Format: "mp3"}
+	events <- batch.Event{Index: 2, Track: tracks[1], Status: batch.StatusSkipped, Reason: "duplicate"}
+	events <- batch.Event{Index: 3, Track: tracks[2], Status: batch.StatusError, Reason: "access denied"}
 	close(events)
 
 	var stdout bytes.Buffer
@@ -131,14 +181,17 @@ func TestConsumeDownloadEventsDrainsAllEventsWithoutInterrupt(t *testing.T) {
 }
 
 func TestConsumeDownloadEventsCallsCancelAndDrainsOnInterrupt(t *testing.T) {
+	tracks := []model.Track{
+		{Title: "First", Artists: []model.Artist{{Name: "One"}}},
+		{Title: "Second", Artists: []model.Artist{{Name: "Two"}}},
+	}
 	events := make(chan batch.Event)
 	interrupt := make(chan struct{})
 
 	go func() {
-		events <- batch.Event{Index: 1, Status: batch.StatusDownloading}
+		events <- batch.Event{Index: 1, Track: tracks[0], Status: batch.StatusDownloading}
 		close(interrupt)
-		events <- batch.Event{Index: 1, Status: batch.StatusDone}
-		events <- batch.Event{Index: 2, Status: batch.StatusError}
+		events <- batch.Event{Index: 1, Track: tracks[0], Status: batch.StatusDone, Format: "mp3"}
 		close(events)
 	}()
 
@@ -154,7 +207,14 @@ func TestConsumeDownloadEventsCallsCancelAndDrainsOnInterrupt(t *testing.T) {
 	if !cancelCalled {
 		t.Fatal("cancel should be called on interrupt")
 	}
-	if summary.downloaded != 1 || summary.failed != 1 {
+	if summary != (batchSummary{downloaded: 1}) {
 		t.Fatalf("unexpected summary: %#v", summary)
+	}
+	if got, want := stdout.String(), strings.Join([]string{
+		"[downloading] One — First",
+		"[done] One — First",
+		"Interrupted: remaining tracks stayed queued",
+	}, "\n")+"\n"; got != want {
+		t.Fatalf("stdout = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary
- Print batch download events as append-only `[status] Artist — Track` lines so previous output stays visible
- Cancel remaining scheduled downloads on Ctrl+C/SIGTERM, keep those tracks queued, and print an interrupt notice before the partial summary
- Document the v1.13.1 behavior in CHANGELOG and README

## Test plan
- [x] `go test ./...`
- [ ] `./yamdl download --token TOKEN --link <album-or-playlist> --output ./downloads` and confirm statuses append instead of overwriting
- [ ] Interrupt a multi-track batch with Ctrl+C and confirm remaining tracks are not started, interrupt message is printed, and exit code is 130